### PR TITLE
Refactor for 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,15 +64,35 @@
           "default": false,
           "description": "Lint every time the document changes. Use with caution."
         },
-        "languageToolLinter.publicApi": {
-          "type": "boolean",
-          "default": false,
-          "description": "Use the public LanguageTool API Service."
+        "languageToolLinter.serviceType": {
+          "type": "string",
+          "default": "custom",
+          "description": "What kind of LanguageTool service to use: external (default), public, or managed.",
+          "enum":[
+            "external",
+            "managed",
+            "public"
+          ],
+          "enumDescriptions": [
+            "Provide a URL to an external LanguageTool service. Defaults to 'http://localhost:8081'. Specify the URL in 'External: Url'.",
+            "Let LanguageTool Linter manage a local service. Specify the path to the script in 'Script'.",
+            "Use the public LanguageTool API Service at https://languagetool.org/api."
+          ]
         },
-        "languageToolLinter.url": {
+        "languageToolLinter.external.url": {
           "type": "string",
           "default": "http://localhost:8081",
           "description": "URL of your LanguageTool server. Defaults to localhost on port 8081."
+        },
+        "languageToolLinter.task.jarFile": {
+          "type": "string",
+          "default": "",
+          "description": "Path to languagetool-server.jar on your local machine."
+        },
+        "languageToolLinter.task.port": {
+          "type": "number",
+          "default": "8081",
+          "description": "Port to use for LanguageTool Server Task."
         },
         "languageToolLinter.languageTool.language": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -219,34 +219,6 @@ function lintDocument(document: vscode.TextDocument): void {
   }
 }
 
-// // Get URL of the LanguageTool service
-// function getCheckUrl(): string | undefined {
-//   let ltConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("languageToolLinter");
-//   const checkPath = "/v2/check";
-//   let ltUrl = ltConfig.get("url");
-//   if (ltConfig.get("publicApi") === true) {
-//     return LT_PUBLIC_URL + checkPath;
-//   } else if (ltUrl && typeof ltUrl === "string") {
-//     return ltUrl + checkPath;
-//   } else {
-//     return undefined;
-//   }
-// }
-
-// // Create the Post Data Dictionary
-// function getPostDataDict(): any {
-//   let ltServiceConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("languageToolLinter.languageTool");
-//   let ltPostDataDict: any = {};
-//   LT_SERVICE_PARAMETERS.forEach(function (ltConfigString) {
-//     let key = ltConfigString;
-//     let value = ltServiceConfig.get(key);
-//     if (value) {
-//       ltPostDataDict[key] = value;
-//     }
-//   });
-//   return ltPostDataDict;
-// }
-
 // Reset the Diagnostic Collection
 function resetDiagnostics(): void {
   diagnosticCollection.clear();


### PR DESCRIPTION
Cleaned stuff up for next release. Main goal is to provide a managed service.

* Service is now controlled by `serviceType`, with one of the following values:
   * `external` (default): Use an external LanguageTool service. URL must be provided in `external.url`.
   * `managed`: Have VS Code manage a LanguageTool service. A path to languagetool-server.jar file must be provided in `task.jarFile`, and a port must be provided in `task.port`.
   * `public`: Uses the public LanguageTool API service.
* Configuration items now loaded on change instead of reading every time lint is called.