### PR TITLE
Fix format command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the "languagetool-linter" extension will be documented in
 
 ## [Unreleased]
 
+## [0.3.2] - 2019-11-04
+
+### Fixed
+
+* `autoFormatCommand` no longer eats the quotes at start of line
+* `autoFormatCommand` no longer converts comments to em-dashes
+
+### Changed
+
+* Use regex in `autoFormatCommand` for simplicity.
+
 ## [0.3.1] - 2019-10-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "languagetool-linter",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -670,9 +670,9 @@
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -322,7 +322,7 @@
     "@types/mocha": "^5.2.6",
     "@types/node": "^10.17.3",
     "@types/vscode": "^1.39.0",
-    "glob": "^7.1.4",
+    "glob": "^7.1.5",
     "mocha": "^6.2.2",
     "tslint": "^5.20.0",
     "typescript": "^3.6.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "languagetool-linter",
   "displayName": "LanguageTool Linter",
   "description": "LanguageTool integration for VS Code.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "engines": {
     "vscode": "^1.39.0"
   },


### PR DESCRIPTION
Switched format command to use regex for code clarity. Fixes:
*  eating quotes at the start of a line
* comments no longer turned to em-dashes

Closes #31 