### PR TITLE
Feature: Replace Jar File with Class Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "languagetool-linter" extension will be documented in
 
 ## [Unreleased]
 
+### Added
+
+* `managed.classPath` setting supports multiple paths and file globbing via [node-glob](https://github.com/isaacs/node-glob). This accomodates various install methods. For example, on Arch Linux using the pacman LanguageTool package, you would set this to `/usr/share/java/languagetool/*.jar`
+
+### Deprecated
+
+* Deprecated `managed.jarFile` setting in favor of `managed.classPath` to align with how the setting was used.
+
 ## [0.3.2] - 2019-11-04
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -670,9 +670,9 @@
       }
     },
     "glob": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
-      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "languageToolLinter.managed.classPath": {
           "type": "string",
           "default": "",
-          "description": "Custom classpath for managed server. Use filesystem separator. File globbing per node-glob."
+          "markdownDescription": "Custom classpath for managed server. Separate multiple paths using the native filesystem separator. Supports file globbing via [node-glob](https://github.com/isaacs/node-glob)."
         },
         "languageToolLinter.languageTool.language": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,11 @@
           "default": "",
           "description": "Path to languagetool-server.jar on your local machine."
         },
+        "languageToolLinter.managed.classPath": {
+          "type": "string",
+          "default": "",
+          "description": "Custom classpath for managed server. Use filesystem separator. File globbing per node-glob."
+        },
         "languageToolLinter.languageTool.language": {
           "type": "string",
           "default": "auto",
@@ -322,7 +327,7 @@
     "@types/mocha": "^5.2.6",
     "@types/node": "^10.17.4",
     "@types/vscode": "^1.39.0",
-    "glob": "^7.1.5",
+    "glob": "^7.1.6",
     "mocha": "^6.2.2",
     "tslint": "^5.20.1",
     "typescript": "^3.6.4",

--- a/src/common/configuration.ts
+++ b/src/common/configuration.ts
@@ -117,20 +117,16 @@ export class ConfigurationManager implements Disposable {
       let jarFile: string = this.get("managed.jarFile") as string;
       let classPath: string = this.get("managed.classPath") as string;
       let classPathFiles: string[] = [];
-      let classPathString: string = "";
       if (jarFile !== "") {
-        classPathString = jarFile;
+        classPathFiles.push(jarFile);
       }
       classPath.split(path.delimiter).forEach((globPattern) => {
         console.log("Glob: " + globPattern);
-        glob(globPattern, (error, matches) => {
-          console.log("Glob Matches: " + matches);
-          matches.forEach((match) => {
-            classPathString += path.delimiter + match;
-            console.log("Class Path String: " + classPathString);
-          });
+        glob.sync(globPattern).forEach((match) => {
+          classPathFiles.push(match);
         });
       });
+      let classPathString: string = classPathFiles.join(path.delimiter);
       console.log("class path: " + classPathString);
       this.stopManagedService();
       portfinder.getPort({ host: "127.0.0.1" }, (error, port) => {


### PR DESCRIPTION
The jarFile setting was being treated as a classPath, so changing the name.
Added the ability to provide multiple paths using native filesystem delimiter and file globbing.

Closes #39 