### PR TITLE
Inline Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "languagetool-linter" extension will be documented in
 
 ## [Unreleased]
 
+### Fixed
+
+* Inline code is interpreted as hashtags, eliminated errors around extra spaces or missing words. ([#40](https://github.com/davidlday/vscode-languagetool-linter/issues/40))
+
 ### Added
 
 * `managed.classPath` setting supports multiple paths and file globbing via [node-glob](https://github.com/isaacs/node-glob). This accomodates various install methods. For example, on Arch Linux using the pacman LanguageTool package, you would set this to `/usr/share/java/languagetool/*.jar`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "languagetool-linter" extension will be documented in
 
 ## [Unreleased]
 
+## [0.4.0] - 2019-11-15
+
 ### Fixed
 
 * Inline code is interpreted as hashtags, eliminated errors around extra spaces or missing words. ([#40](https://github.com/davidlday/vscode-languagetool-linter/issues/40))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "languagetool-linter",
   "displayName": "LanguageTool Linter",
   "description": "LanguageTool integration for VS Code.",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "engines": {
     "vscode": "^1.40.0"
   },

--- a/src/linter/commands.ts
+++ b/src/linter/commands.ts
@@ -28,11 +28,25 @@ export class LinterCommands {
   diagnosticCollection: DiagnosticCollection;
   diagnosticMap: Map<string, Diagnostic[]> = new Map();
   codeActionMap: Map<string, CodeAction[]> = new Map();
+  remarkBuilderOptions: any = remarkBuilder.defaults;
 
   constructor(config: ConfigurationManager) {
     this.config = config;
     this.timeoutMap = new Map();
     this.diagnosticCollection = languages.createDiagnosticCollection(LT_DISPLAY_NAME);
+
+    // Custom markdown interpretation
+    this.remarkBuilderOptions.interpretmarkup = function (text: string) {
+      let interpretation = "";
+      // Treat inline code as redacted text
+      if (text.match(/^(?!\s*`{3})\s*`{1,2}/)) {
+        interpretation = "`" + "#".repeat(text.length - 2) + "`";
+      } else {
+        let count = (text.match(/\n/g) || []).length;
+        interpretation = "\n".repeat(count);
+      }
+      return interpretation;
+    };
   }
 
   deleteFromDiagnosticCollection(uri: Uri): void {
@@ -79,7 +93,7 @@ export class LinterCommands {
   lintDocument(document: TextDocument): void {
     if (this.config.isSupportedDocument(document)) {
       if (document.languageId === "markdown") {
-        let annotatedMarkdown: string = JSON.stringify(remarkBuilder.build(document.getText()));
+        let annotatedMarkdown: string = JSON.stringify(remarkBuilder.build(document.getText(), this.remarkBuilderOptions));
         this.lintAnnotatedText(document, annotatedMarkdown);
       } else if (document.languageId === "html") {
         let annotatedHTML: string = JSON.stringify(rehypeBuilder.build(document.getText()));

--- a/src/linter/commands.ts
+++ b/src/linter/commands.ts
@@ -36,7 +36,7 @@ export class LinterCommands {
     this.diagnosticCollection = languages.createDiagnosticCollection(LT_DISPLAY_NAME);
 
     // Custom markdown interpretation
-    this.remarkBuilderOptions.interpretmarkup = function (text: string) {
+    this.remarkBuilderOptions.interpretmarkup = (text: string) => {
       let interpretation = "";
       // Treat inline code as redacted text
       if (text.match(/^(?!\s*`{3})\s*`{1,2}/)) {


### PR DESCRIPTION
Inline Code treated as redacted text. LanguageTool ignores sees text but ignores it.

Closes #40 