### PR TITLE
Smarter format

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,8 @@
         "annotatedtext",
         "annotatedtext-remark",
         "api",
+        "de-at",
+        "de-de",
         "globbing",
         "http-proxy-agent",
         "languagetool-linter",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,8 @@
         "npmjs",
         "pacman",
         "plaintext",
-        "voss"
+        "voss",
+        "yaml"
     ],
     "languageToolLinter.languageTool.disabledRules": "DASH_RULE"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the “languagetool-linter” extension will be documente
 
 ## [Unreleased]
 
+Changes not yet released.
+
+### Changed
+
+* Auto Format renamed to Smart Format since it only formats smart characters.
+
 ## [0.9.1] - 2019-12-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ Changes not yet released.
 
 ### Fixed
 
-* Header marks reduced to only single has instead of entire markup to prevent passing front matter.
-* Smart Format command only applies smart format to text and skips markup.
+* Header marks reduced to only single has instead of entire markup to prevent passing front matter
+* Smart Format command only applies smart format to text and skips markup
 
 ### Changed
 
-* Auto Format renamed to Smart Format since it only formats smart characters.
+* Auto Format Enabled renamed to Smart Format on Type since it only formats smart characters
 
 ## [0.9.1] - 2019-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes not yet released.
 ### Fixed
 
 * Header marks reduced to only single has instead of entire markup to prevent passing front matter.
+* Smart Format command only applies smart format to text and skips markup.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -31,18 +31,18 @@ If this doesn't work for you, here are your options.
 
 This could either be a [locally running instance](https://github.com/davidlday/vscode-languagetool-linter/wiki#run-a-local-languagetool-service) of LanguageTool, or the service running somewhere else.
 
-1. Set the URL in "LanguageTool Linter > External: Url" (i.e. `http://localhost:8081`).
-1. Set "LanguageTool Linter: Service Type" to `external`.
+1. Set the URL in “LanguageTool Linter > External: URL” (i.e. `http://localhost:8081`).
+1. Set “LanguageTool Linter: Service Type” to `external`.
 
 ![External URL](images/external.gif)
 
 ### Option 2: Use an Extension-Managed Service
 
-Works well if you're only using LangaugeTool in Visual Studio Code.
+Works well if you're only using LanguageTool in Visual Studio Code.
 
 1. [Install LanguageTool](https://github.com/davidlday/vscode-languagetool-linter/wiki#installing-languagetool) locally.
-1. Set "LanguageTool Linter > Managed: Jar File" to the location of the `languagetool-server.jar` file. The install doc has hints.
-1. Set "LanguageTool Linter: Service Type" to `managed`.
+1. Set “LanguageTool Linter > Managed: Jar File” to the location of the `languagetool-server.jar` file. The install doc has hints.
+1. Set “LanguageTool Linter: Service Type” to `managed`.
 
 ![Managed Service](images/managed.gif)
 
@@ -50,7 +50,7 @@ Works well if you're only using LangaugeTool in Visual Studio Code.
 
 Make sure you read and understand [LanguageTool's Public API](http://wiki.languagetool.org/public-http-api) before doing this.
 
-1. Set "LanguageTool Linter: Service Type" to `public`.
+1. Set “LanguageTool Linter: Service Type” to `public`.
 
 ![Public API](images/public.gif)
 
@@ -60,13 +60,13 @@ Most configuration items should be safe, but there are three you should pay part
 
 1. *Public Api*: This will use [LanguageTool's Public API](http://wiki.languagetool.org/public-http-api) service. If you violate their conditions, they'll block your IP address.
 2. *Lint on Change*: This will make a call to the LanguageTool API on every change. If you mix this with the *Public Api*, you're more likely to violate their conditions and get your IP address blocked.
-3. *Language Tool: Preferred Variants*: If you set this, then *Language Tool: Language* must be set to `auto`. If it isn't, the service will throw an error.
+3. *LanguageTool: Preferred Variants*: If you set this, then *LanguageTool: Language* must be set to `auto`. If it isn't, the service will throw an error.
 
 ## Credits
 
 The following projects provided excellent guidance on creating this project.
 
-* [LaguageTool](https://languagetool.org) (of course!)
+* [LanguageTool](https://languagetool.org) (of course!)
 * [Atom Linter LanguageTool](https://github.com/wysiib/linter-languagetool/)
 * [LT<sub>e</sub>X](https://github.com/valentjn/vscode-ltex) — a fork of [LanguageTool for Visual Studio Code](https://github.com/languagetool-language-server/vscode-languagetool)
 * [VS Code Write Good Extension](https://github.com/TravisTheTechie/vscode-write-good/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,12 +29,6 @@
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
-    "@types/chai": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.5.tgz",
-      "integrity": "sha512-YvbLiIc0DbbhiANrfVObdkLEHJksQZVq0Uvfg550SRAKVYaEJy+V70j65BVe2WNp6E3HtKsUczeijHFCjba3og==",
-      "dev": true
-    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -205,12 +199,6 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "async": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
@@ -289,20 +277,6 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
       "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w=="
     },
-    "chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
-        "type-detect": "^4.0.5"
-      }
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -339,12 +313,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
       "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg=="
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true
     },
     "cliui": {
       "version": "5.0.0",
@@ -475,15 +443,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
-      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -688,12 +647,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stream": {
@@ -1280,12 +1233,6 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
-    "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -1682,12 +1629,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
     },
     "typescript": {
       "version": "3.7.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "onLanguage:markdown",
     "onLanguage:html",
     "onCommand:languagetoolLinter.lintCurrentDocument",
-    "onCommand:languagetoolLinter.autoFormatDocument"
+    "onCommand:languagetoolLinter.smartFormatDocument"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -52,7 +52,7 @@
         "category": "LanguageTool Linter"
       },
       {
-        "command": "languagetoolLinter.autoFormatDocument",
+        "command": "languagetoolLinter.smartFormatDocument",
         "title": "Auto Format Document",
         "category": "LanguageTool Linter"
       }
@@ -61,10 +61,10 @@
       "type": "object",
       "title": "LanguageTool Linter",
       "properties": {
-        "languageToolLinter.autoformat.enabled": {
+        "languageToolLinter.smartformat.enabled": {
           "type": "boolean",
           "default": false,
-          "description": "Run autoformat as you type for quotes (“”,‘’), em-dashes and en-dashes, and ellipses (…). Ensure 'Editor: Format On Type' is enabled."
+          "description": "Run smart format as you type for quotes (“”,‘’), em-dashes and en-dashes, and ellipses (…). Ensure 'Editor: Format On Type' is enabled."
         },
         "languageToolLinter.enabled": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -343,12 +343,10 @@
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
-    "@types/chai": "^4.2.5",
     "@types/glob": "^7.1.1",
     "@types/mocha": "^5.2.6",
     "@types/node": "^10.17.6",
     "@types/vscode": "^1.39.0",
-    "chai": "^4.2.0",
     "mocha": "^6.2.2",
     "tslint": "^5.20.1",
     "typescript": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
       "type": "object",
       "title": "LanguageTool Linter",
       "properties": {
-        "languageToolLinter.smartFormat.enabled": {
+        "languageToolLinter.smartFormat.onType": {
           "type": "boolean",
           "default": false,
           "description": "Run smart format as you type for quotes (“”,‘’), em-dashes and en-dashes, and ellipses (…). Ensure 'Editor: Format On Type' is enabled."

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
       "type": "object",
       "title": "LanguageTool Linter",
       "properties": {
-        "languageToolLinter.smartformat.enabled": {
+        "languageToolLinter.smartFormat.enabled": {
           "type": "boolean",
           "default": false,
           "description": "Run smart format as you type for quotes (“”,‘’), em-dashes and en-dashes, and ellipses (…). Ensure 'Editor: Format On Type' is enabled."

--- a/src/common/configuration-manager.ts
+++ b/src/common/configuration-manager.ts
@@ -67,8 +67,9 @@ export class ConfigurationManager implements Disposable {
     this.workspaceIgnoredWords = this.getWorkspaceIgnoredWords();
   }
 
-  isSmartFormatEnabled(): boolean {
-    return this.config.get("smartFormat.enabled") as boolean;
+  // Smart Format on Type
+  isSmartFormatOnType(): boolean {
+    return this.config.get("smartFormat.onType") as boolean;
   }
 
   // Is Language ID Supported?

--- a/src/common/configuration-manager.ts
+++ b/src/common/configuration-manager.ts
@@ -68,7 +68,7 @@ export class ConfigurationManager implements Disposable {
   }
 
   isSmartFormatEnabled(): boolean {
-    return this.config.get("smartformat.enabled") as boolean;
+    return this.config.get("smartFormat.enabled") as boolean;
   }
 
   // Is Language ID Supported?

--- a/src/common/configuration-manager.ts
+++ b/src/common/configuration-manager.ts
@@ -60,8 +60,8 @@ export class ConfigurationManager implements Disposable {
     this.workspaceIgnoredWords = this.getWorkspaceIgnoredWords();
   }
 
-  isAutoFormatEnabled(): boolean {
-    return this.config.get("autoformat.enabled") as boolean;
+  isSmartFormatEnabled(): boolean {
+    return this.config.get("smartformat.enabled") as boolean;
   }
 
   // Is Language ID Supported?

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,7 +146,7 @@ export function activate(context: vscode.ExtensionContext) {
       let text: string = editor.document.getText();
       let lastOffset: number = text.length - 1;
       let annotatedtext: IAnnotatedtext = linter.buildAnnotatedtext(editor.document);
-      let newText = Linter.smartFormatAnnotatedtext(annotatedtext);
+      let newText = linter.smartFormatAnnotatedtext(annotatedtext);
       // Replace the whole thing at once so undo applies to all changes.
       edit.replace(
         new vscode.Range(editor.document.positionAt(0), editor.document.positionAt(lastOffset)),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { QuotesFormattingProvider } from './typeFormatters/quotesFormatter';
 import { LT_DOCUMENT_SELECTORS, LT_OUTPUT_CHANNEL, LT_TIMEOUT_MS, LT_SERVICE_MANAGED } from './common/constants';
 import { ConfigurationManager } from "./common/configuration-manager";
 import { Linter } from "./linter/linter";
+import { IAnnotatedtext } from "./linter/interfaces";
 
 // Wonder Twin Powers, Activate!
 export function activate(context: vscode.ExtensionContext) {
@@ -139,26 +140,42 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(lintCommand);
 
   // Register "Auto Format Document" TextEditorCommand
-  let autoFormatCommand = vscode.commands.registerTextEditorCommand("languagetoolLinter.autoFormatDocument", (editor, edit) => {
+  let smartFormatCommand = vscode.commands.registerTextEditorCommand("languagetoolLinter.smartFormatDocument", (editor, edit) => {
     if (configMan.isSupportedDocument(editor.document)) {
       // Revert to regex here for cleaner code.
       let text: string = editor.document.getText();
       let lastOffset: number = text.length - 1;
-      text = text.replace(/"(?=[\w'‘])/g, QuotesFormattingProvider.startDoubleQuote)
-        .replace(/'(?=[\w"“])/g, QuotesFormattingProvider.startSingleQuote)
-        .replace(/([\w.!?%,'’])"/g, "$1" + QuotesFormattingProvider.endDoubleQuote)
-        .replace(/([\w.!?%,"”])'/g, "$1" + QuotesFormattingProvider.endSingleQuote)
-        .replace(/([\w])---(?=[\w])/g, "$1" + DashesFormattingProvider.emDash)
-        .replace(/([\w])--(?=[\w])/g, "$1" + DashesFormattingProvider.enDash)
-        .replace(/\.\.\./g, EllipsesFormattingProvider.ellipses);
+      let annotatedtext: IAnnotatedtext = linter.buildAnnotatedtext(editor.document);
+      let newText: string = "";
+      // Only run substitutions on text annotations.
+      annotatedtext.annotation.forEach((annotation) => {
+        if (annotation.text) {
+          newText += annotation.text.replace(/"(?=[\w'‘])/g, QuotesFormattingProvider.startDoubleQuote)
+            .replace(/'(?=[\w"“])/g, QuotesFormattingProvider.startSingleQuote)
+            .replace(/([\w.!?%,'’])"/g, "$1" + QuotesFormattingProvider.endDoubleQuote)
+            .replace(/([\w.!?%,"”])'/g, "$1" + QuotesFormattingProvider.endSingleQuote)
+            .replace(/([\w])---(?=[\w])/g, "$1" + DashesFormattingProvider.emDash)
+            .replace(/([\w])--(?=[\w])/g, "$1" + DashesFormattingProvider.enDash)
+            .replace(/\.\.\./g, EllipsesFormattingProvider.ellipses);
+        } else if (annotation.markdown) {
+          newText += annotation.markdown;
+        }
+      });
+      // text = text.replace(/"(?=[\w'‘])/g, QuotesFormattingProvider.startDoubleQuote)
+      //   .replace(/'(?=[\w"“])/g, QuotesFormattingProvider.startSingleQuote)
+      //   .replace(/([\w.!?%,'’])"/g, "$1" + QuotesFormattingProvider.endDoubleQuote)
+      //   .replace(/([\w.!?%,"”])'/g, "$1" + QuotesFormattingProvider.endSingleQuote)
+      //   .replace(/([\w])---(?=[\w])/g, "$1" + DashesFormattingProvider.emDash)
+      //   .replace(/([\w])--(?=[\w])/g, "$1" + DashesFormattingProvider.enDash)
+      //   .replace(/\.\.\./g, EllipsesFormattingProvider.ellipses);
       // Replace the whole thing at once so undo applies to all changes.
       edit.replace(
         new vscode.Range(editor.document.positionAt(0), editor.document.positionAt(lastOffset)),
-        text
+        newText
       );
     }
   });
-  context.subscriptions.push(autoFormatCommand);
+  context.subscriptions.push(smartFormatCommand);
 
   // Lint Active Text Editor on Activate
   if (vscode.window.activeTextEditor) {

--- a/src/linter/interfaces.ts
+++ b/src/linter/interfaces.ts
@@ -76,7 +76,7 @@ export interface ILanguageToolReplacement {
 }
 
 export interface IAnnotation {
-  markdown?: string;
+  markup?: string;
   interpretAs?: string;
   text?: string;
   offset?: {

--- a/src/linter/interfaces.ts
+++ b/src/linter/interfaces.ts
@@ -74,3 +74,17 @@ export interface ILanguageToolReplacement {
   value: string;
   shortDescription: string;
 }
+
+export interface IAnnotation {
+  markdown?: string;
+  interpretAs?: string;
+  text?: string;
+  offset?: {
+    start: number;
+    end: number
+  };
+}
+
+export interface IAnnotatedtext {
+  annotation: IAnnotation[];
+}

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -24,6 +24,9 @@ import * as rp from "request-promise-native";
 import * as rehypeBuilder from "annotatedtext-rehype";
 import * as remarkBuilder from "annotatedtext-remark";
 import { ILanguageToolResponse, ILanguageToolMatch, ILanguageToolReplacement, IAnnotatedtext, IAnnotation } from './interfaces';
+import { QuotesFormattingProvider } from '../typeFormatters/quotesFormatter';
+import { DashesFormattingProvider } from '../typeFormatters/dashesFormatter';
+import { EllipsesFormattingProvider } from '../typeFormatters/ellipsesFormatter';
 
 export class Linter implements CodeActionProvider {
   private readonly configManager: ConfigurationManager;
@@ -67,6 +70,7 @@ export class Linter implements CodeActionProvider {
     return interpretation;
   }
 
+  // Provide CodeActions for thw given Document and Range
   provideCodeActions(
     document: TextDocument,
     range: Range,
@@ -74,9 +78,8 @@ export class Linter implements CodeActionProvider {
     token: CancellationToken
   ): CodeAction[] {
     let documentUri: string = document.uri.toString();
-    let codeActionMap: Map<string, CodeAction[]> = this.getCodeActionMap();
-    if (codeActionMap.has(documentUri) && codeActionMap.get(documentUri)) {
-      let documentCodeActions: CodeAction[] = codeActionMap.get(documentUri) || [];
+    if (this.codeActionMap.has(documentUri) && this.codeActionMap.get(documentUri)) {
+      let documentCodeActions: CodeAction[] = this.codeActionMap.get(documentUri) || [];
       let actions: CodeAction[] = [];
       documentCodeActions.forEach(function (action) {
         if (action.diagnostics && context.diagnostics) {
@@ -92,20 +95,9 @@ export class Linter implements CodeActionProvider {
     }
   }
 
+  // Delete a set of diagnostics for the given Document URI
   deleteFromDiagnosticCollection(uri: Uri): void {
     this.diagnosticCollection.delete(uri);
-  }
-
-  getDiagnosticCollection(): DiagnosticCollection {
-    return this.diagnosticCollection;
-  }
-
-  getDiagnosticMap(): Map<string, Diagnostic[]> {
-    return this.diagnosticMap;
-  }
-
-  getCodeActionMap(): Map<string, CodeAction[]> {
-    return this.codeActionMap;
   }
 
   requestLint(document: TextDocument, timeoutDuration: number = LT_TIMEOUT_MS): void {
@@ -256,6 +248,7 @@ export class Linter implements CodeActionProvider {
     this.resetDiagnostics();
   }
 
+  // Get CodeActions for Spelling Rules
   private getSpellingRuleActions(document: TextDocument, diagnostic: Diagnostic, match: ILanguageToolMatch): CodeAction[] {
     let actions: CodeAction[] = [];
     let word: string = document.getText(diagnostic.range);
@@ -302,6 +295,7 @@ export class Linter implements CodeActionProvider {
     return actions;
   }
 
+  // Get all Rule CodeActions
   private getRuleActions(document: TextDocument, diagnostic: Diagnostic, match: ILanguageToolMatch): CodeAction[] {
     let actions: CodeAction[] = [];
     this.getReplacementActions(document, diagnostic, match.replacements).forEach((action: CodeAction) => {
@@ -310,6 +304,7 @@ export class Linter implements CodeActionProvider {
     return actions;
   }
 
+  // Get all edit CodeActions based on Replacements
   private getReplacementActions(document: TextDocument, diagnostic: Diagnostic, replacements: ILanguageToolReplacement[]): CodeAction[] {
     let actions: CodeAction[] = [];
     replacements.forEach((replacement: ILanguageToolReplacement) => {
@@ -339,6 +334,26 @@ export class Linter implements CodeActionProvider {
     return ruleId.indexOf("MORFOLOGIK_RULE") !== -1 || ruleId.indexOf("SPELLER_RULE") !== -1
       || ruleId.indexOf("HUNSPELL_NO_SUGGEST_RULE") !== -1 || ruleId.indexOf("HUNSPELL_RULE") !== -1
       || ruleId.indexOf("FR_SPELLING_RULE") !== -1;
+  }
+
+  // Apply smart formatting to annotated text.
+  static smartFormatAnnotatedtext(annotatedtext: IAnnotatedtext): string {
+    let newText: string = "";
+    // Only run substitutions on text annotations.
+    annotatedtext.annotation.forEach((annotation) => {
+      if (annotation.text) {
+        newText += annotation.text.replace(/"(?=[\w'‘])/g, QuotesFormattingProvider.startDoubleQuote)
+          .replace(/'(?=[\w"“])/g, QuotesFormattingProvider.startSingleQuote)
+          .replace(/([\w.!?%,'’])"/g, "$1" + QuotesFormattingProvider.endDoubleQuote)
+          .replace(/([\w.!?%,"”])'/g, "$1" + QuotesFormattingProvider.endSingleQuote)
+          .replace(/([\w])---(?=[\w])/g, "$1" + DashesFormattingProvider.emDash)
+          .replace(/([\w])--(?=[\w])/g, "$1" + DashesFormattingProvider.enDash)
+          .replace(/\.\.\./g, EllipsesFormattingProvider.ellipses);
+      } else if (annotation.markdown) {
+        newText += annotation.markdown;
+      }
+    });
+    return newText;
   }
 
 }

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -16,7 +16,8 @@
 
 import {
   TextDocument, WorkspaceEdit, CodeAction, Location, Diagnostic, Position,
-  Range, CodeActionKind, DiagnosticSeverity, DiagnosticCollection, languages, Uri, CodeActionProvider, CodeActionContext, CancellationToken, workspace
+  Range, CodeActionKind, DiagnosticSeverity, DiagnosticCollection, languages, Uri,
+  CodeActionProvider, CodeActionContext, CancellationToken, workspace
 } from 'vscode';
 import { ConfigurationManager } from '../common/configuration-manager';
 import { LT_TIMEOUT_MS, LT_OUTPUT_CHANNEL, LT_DIAGNOSTIC_SOURCE, LT_DISPLAY_NAME, MARKDOWN, HTML, PLAINTEXT } from '../common/constants';
@@ -39,7 +40,7 @@ export class Linter implements CodeActionProvider {
 
   constructor(configManager: ConfigurationManager) {
     this.configManager = configManager;
-    this.timeoutMap = new Map();
+    this.timeoutMap = new Map<string, NodeJS.Timeout>();
     this.diagnosticCollection = languages.createDiagnosticCollection(LT_DISPLAY_NAME);
 
     this.remarkBuilderOptions.interpretmarkup = this.customMarkdownInterpreter;

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -333,7 +333,7 @@ export class Linter implements CodeActionProvider {
   }
 
   // Apply smart formatting to annotated text.
-  static smartFormatAnnotatedtext(annotatedtext: IAnnotatedtext): string {
+  smartFormatAnnotatedtext(annotatedtext: IAnnotatedtext): string {
     let newText: string = "";
     // Only run substitutions on text annotations.
     annotatedtext.annotation.forEach((annotation) => {
@@ -345,8 +345,8 @@ export class Linter implements CodeActionProvider {
           .replace(/([\w])---(?=[\w])/g, "$1" + DashesFormattingProvider.emDash)
           .replace(/([\w])--(?=[\w])/g, "$1" + DashesFormattingProvider.enDash)
           .replace(/\.\.\./g, EllipsesFormattingProvider.ellipses);
-      } else if (annotation.markdown) {
-        newText += annotation.markdown;
+      } else if (annotation.markup) {
+        newText += annotation.markup;
       }
     });
     return newText;

--- a/src/test-fixtures/workspace/.vscode/settings.json
+++ b/src/test-fixtures/workspace/.vscode/settings.json
@@ -2,7 +2,9 @@
     "languageToolLinter.languageTool.ignoredWordsInWorkspace": [
         "backticks",
         "languagetool-linter",
-        "misspeeled"
+        "linter",
+        "misspeeled",
+        "yaml"
     ],
     "languageToolLinter.languageTool.disabledRules": "DASH_RULE"
 }

--- a/src/test-fixtures/workspace/markdown/comments.json
+++ b/src/test-fixtures/workspace/markdown/comments.json
@@ -1,0 +1,57 @@
+{
+  "annotation": [
+    {
+      "markup": "# ",
+      "interpretAs": "# ",
+      "offset": {
+        "start": 0,
+        "end": 2
+      }
+    },
+    {
+      "text": "Comments Test Case",
+      "offset": {
+        "start": 2,
+        "end": 20
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 20,
+        "end": 22
+      }
+    },
+    {
+      "text": "Smart formatting should ignore comments.",
+      "offset": {
+        "start": 22,
+        "end": 62
+      }
+    },
+    {
+      "markup": "\n\n<!--\nLike this.\nUnfortunately the linter will also ignore comments.\n-->\n\n",
+      "interpretAs": "\n\n\n\n\n\n\n",
+      "offset": {
+        "start": 62,
+        "end": 137
+      }
+    },
+    {
+      "text": "But that’s okay for now.",
+      "offset": {
+        "start": 137,
+        "end": 161
+      }
+    },
+    {
+      "markup": "\n",
+      "interpretAs": "\n",
+      "offset": {
+        "start": 161,
+        "end": 162
+      }
+    }
+  ]
+}

--- a/src/test-fixtures/workspace/markdown/comments.md
+++ b/src/test-fixtures/workspace/markdown/comments.md
@@ -1,0 +1,10 @@
+# Comments Test Case
+
+Smart formatting should ignore comments.
+
+<!--
+Like this.
+Unfortunately the linter will also ignore comments.
+-->
+
+But that’s okay for now.

--- a/src/test-fixtures/workspace/markdown/smart-format-formatted.md
+++ b/src/test-fixtures/workspace/markdown/smart-format-formatted.md
@@ -11,7 +11,7 @@ Make sure the smart format command only applies formatting to text and skips all
 
 ## Smart Quotes
 
-This “sentence" contains ‘quotes’.
+This “sentence” contains ‘quotes’.
 
 ## Ellipses
 

--- a/src/test-fixtures/workspace/markdown/smart-format-formatted.md
+++ b/src/test-fixtures/workspace/markdown/smart-format-formatted.md
@@ -1,0 +1,24 @@
+---
+title: "Smart Format Test Case"
+singlequotes: "'"
+doublequotes: '"'
+ellipses: "..."
+endash: "--"
+emdash: "---"
+---
+
+Make sure the smart format command only applies formatting to text and skips all markdown, such as this front matter.
+
+## Smart Quotes
+
+This “sentence" contains ‘quotes’.
+
+## Ellipses
+
+This sentence ends with ellipses…
+
+## Dashes
+
+This non–sense sentence contains en-dashes.
+
+This sentence—if you can call it that—contains em-dashes.

--- a/src/test-fixtures/workspace/markdown/smart-format-formatted.md
+++ b/src/test-fixtures/workspace/markdown/smart-format-formatted.md
@@ -22,3 +22,9 @@ This sentence ends with ellipses…
 This non–sense sentence contains en-dashes.
 
 This sentence—if you can call it that—contains em-dashes.
+
+## Comments
+
+Smart formatting should ignore comment brackets.
+
+<!-- "Like this," he said... But---at least I think---so will the linter. -->

--- a/src/test-fixtures/workspace/markdown/smart-format-unformatted.json
+++ b/src/test-fixtures/workspace/markdown/smart-format-unformatted.json
@@ -1,0 +1,132 @@
+{
+  "annotation": [
+    {
+      "markup": "---\ntitle: \"Smart Format Test Case\"\nsinglequotes: \"'\"\ndoublequotes: '\"'\nellipses: \"...\"\nendash: \"--\"\nemdash: \"---\"\n---\n\n",
+      "interpretAs": "\n\n\n\n\n\n\n\n\n",
+      "offset": {
+        "start": 0,
+        "end": 120
+      }
+    },
+    {
+      "text": "Make sure the smart format command only applies formatting to text and skips all markdown, such as this front matter.",
+      "offset": {
+        "start": 120,
+        "end": 237
+      }
+    },
+    {
+      "markup": "\n\n## ",
+      "interpretAs": "\n\n# ",
+      "offset": {
+        "start": 237,
+        "end": 242
+      }
+    },
+    {
+      "text": "Smart Quotes",
+      "offset": {
+        "start": 242,
+        "end": 254
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 254,
+        "end": 256
+      }
+    },
+    {
+      "text": "This \"sentence\" contains 'quotes'.",
+      "offset": {
+        "start": 256,
+        "end": 290
+      }
+    },
+    {
+      "markup": "\n\n## ",
+      "interpretAs": "\n\n# ",
+      "offset": {
+        "start": 290,
+        "end": 295
+      }
+    },
+    {
+      "text": "Ellipses",
+      "offset": {
+        "start": 295,
+        "end": 303
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 303,
+        "end": 305
+      }
+    },
+    {
+      "text": "This sentence ends with ellipses...",
+      "offset": {
+        "start": 305,
+        "end": 340
+      }
+    },
+    {
+      "markup": "\n\n## ",
+      "interpretAs": "\n\n# ",
+      "offset": {
+        "start": 340,
+        "end": 345
+      }
+    },
+    {
+      "text": "Dashes",
+      "offset": {
+        "start": 345,
+        "end": 351
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 351,
+        "end": 353
+      }
+    },
+    {
+      "text": "This non--sense sentence contains en-dashes.",
+      "offset": {
+        "start": 353,
+        "end": 397
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 397,
+        "end": 399
+      }
+    },
+    {
+      "text": "This sentence---if you can call it that---contains em-dashes.",
+      "offset": {
+        "start": 399,
+        "end": 460
+      }
+    },
+    {
+      "markup": "\n",
+      "interpretAs": "\n",
+      "offset": {
+        "start": 460,
+        "end": 461
+      }
+    }
+  ]
+}

--- a/src/test-fixtures/workspace/markdown/smart-format-unformatted.json
+++ b/src/test-fixtures/workspace/markdown/smart-format-unformatted.json
@@ -121,11 +121,41 @@
       }
     },
     {
-      "markup": "\n",
-      "interpretAs": "\n",
+      "markup": "\n\n## ",
+      "interpretAs": "\n\n# ",
       "offset": {
         "start": 460,
-        "end": 461
+        "end": 465
+      }
+    },
+    {
+      "offset": {
+        "end": 473,
+        "start": 465
+      },
+      "text": "Comments"
+    },
+    {
+      "interpretAs": "\n\n",
+      "markup": "\n\n",
+      "offset": {
+        "end": 475,
+        "start": 473
+      }
+    },
+    {
+      "offset": {
+        "end": 523,
+        "start": 475
+      },
+      "text": "Smart formatting should ignore comment brackets."
+    },
+    {
+      "interpretAs": "\n\n\n",
+      "markup": "\n\n<!-- \"Like this,\" he said... But---at least I think---so will the linter. -->\n",
+      "offset": {
+        "end": 603,
+        "start": 523
       }
     }
   ]

--- a/src/test-fixtures/workspace/markdown/smart-format-unformatted.md
+++ b/src/test-fixtures/workspace/markdown/smart-format-unformatted.md
@@ -1,0 +1,24 @@
+---
+title: "Smart Format Test Case"
+singlequotes: "'"
+doublequotes: '"'
+ellipses: "..."
+endash: "--"
+emdash: "---"
+---
+
+Make sure the smart format command only applies formatting to text and skips all markdown, such as this front matter.
+
+## Smart Quotes
+
+This "sentence" contains 'quotes'.
+
+## Ellipses
+
+This sentence ends with ellipses...
+
+## Dashes
+
+This non--sense sentence contains en-dashes.
+
+This sentence---if you can call it that---contains em-dashes.

--- a/src/test-fixtures/workspace/markdown/smart-format-unformatted.md
+++ b/src/test-fixtures/workspace/markdown/smart-format-unformatted.md
@@ -22,3 +22,9 @@ This sentence ends with ellipses...
 This non--sense sentence contains en-dashes.
 
 This sentence---if you can call it that---contains em-dashes.
+
+## Comments
+
+Smart formatting should ignore comment brackets.
+
+<!-- "Like this," he said... But---at least I think---so will the linter. -->

--- a/src/test-fixtures/workspace/markdown/smart-format.md
+++ b/src/test-fixtures/workspace/markdown/smart-format.md
@@ -1,0 +1,5 @@
+---
+title: "Smart Format Test Document"
+subtitle: "How I stopped worrying and learned to love the smart quotes."
+---
+

--- a/src/test/suite/configuration.test.ts
+++ b/src/test/suite/configuration.test.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import { before } from 'mocha';
 import * as vscode from 'vscode';
 import { ConfigurationManager } from '../../common/configuration-manager';
 import * as constants from '../../common/constants';

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,9 +1,6 @@
 import * as assert from 'assert';
 import { before } from 'mocha';
 import * as vscode from 'vscode';
-import * as linter from '../../linter/linter';
-import * as configman from '../../common/configuration-manager';
-import * as constants from '../../common/constants';
 
 // import * as languagetooLinter from '../';
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -27,7 +27,7 @@ suite('Extension Test Suite', () => {
   test('Extension should register all commands', () => {
     return vscode.commands.getCommands(true).then((commands) => {
       const EXPECTED_COMMANDS: string[] = ["languagetoolLinter.lintCurrentDocument",
-        "languagetoolLinter.autoFormatDocument",
+        "languagetoolLinter.smartFormatDocument",
         "languagetoolLinter.ignoreWordGlobally",
         "languagetoolLinter.ignoreWordInWorkspace",
         "languagetoolLinter.removeGloballyIgnoredWord",

--- a/src/test/suite/linter.markdown.test.ts
+++ b/src/test/suite/linter.markdown.test.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import * as chai from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ConfigurationManager } from '../../common/configuration-manager';
@@ -18,42 +17,42 @@ suite('Linter Markdown Test Suite', () => {
   test('Linter should return annotated text for Markdown with Backticks', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/backticks.json"), "utf8"));
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/backticks.md"), "utf8");
-    const result = linter.buildAnnotatedMarkdown(text);
-    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/backticks.json"), JSON.stringify(result), "utf8");
-    assert.ok(chai.expect(result).to.deep.equal(expected));
+    const actual = linter.buildAnnotatedMarkdown(text);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/backticks.json"), JSON.stringify(actual), "utf8");
+    assert.deepStrictEqual(actual, expected);
   });
 
   test('Linter should return annotated text for Markdown with Front Matter (YAML)', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/front-matter.json"), "utf8"));
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/front-matter.md"), "utf8");
-    const result = linter.buildAnnotatedMarkdown(text);
-    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/front-matter.json"), JSON.stringify(result), "utf8");
-    assert.ok(chai.expect(result).to.deep.equal(expected));
+    const actual = linter.buildAnnotatedMarkdown(text);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/front-matter.json"), JSON.stringify(actual), "utf8");
+    assert.deepStrictEqual(actual, expected);
   });
 
 
   test('Linter should return annotated text for Markdown with Headers', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/headers.json"), "utf8"));
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/headers.md"), "utf8");
-    const result = linter.buildAnnotatedMarkdown(text);
-    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/headers.json"), JSON.stringify(result), "utf8");
-    assert.ok(chai.expect(result).to.deep.equal(expected));
+    const actual = linter.buildAnnotatedMarkdown(text);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/headers.json"), JSON.stringify(actual), "utf8");
+    assert.deepStrictEqual(actual, expected);
   });
 
   test('Linter should return annotated text for Markdown with Ordered Lists', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/ordered-lists.json"), "utf8"));
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/ordered-lists.md"), "utf8");
-    const result = linter.buildAnnotatedMarkdown(text);
-    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/ordered-lists.json"), JSON.stringify(result), "utf8");
-    assert.ok(chai.expect(result).to.deep.equal(expected));
+    const actual = linter.buildAnnotatedMarkdown(text);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/ordered-lists.json"), JSON.stringify(actual), "utf8");
+    assert.deepStrictEqual(actual, expected);
   });
 
   test('Linter should return annotated text for Markdown with Unordered Lists', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.json"), "utf8"));
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.md"), "utf8");
-    const result = linter.buildAnnotatedMarkdown(text);
-    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.json"), JSON.stringify(result), "utf8");
-    assert.ok(chai.expect(result).to.deep.equal(expected));
+    const actual = linter.buildAnnotatedMarkdown(text);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.json"), JSON.stringify(actual), "utf8");
+    assert.deepStrictEqual(actual, expected);
   });
 
 });

--- a/src/test/suite/linter.markdown.test.ts
+++ b/src/test/suite/linter.markdown.test.ts
@@ -22,6 +22,14 @@ suite('Linter Markdown Test Suite', () => {
     assert.deepStrictEqual(actual, expected);
   });
 
+  test('Linter should return annotated text for Markdown with Comments', () => {
+    const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/comments.json"), "utf8"));
+    const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/comments.md"), "utf8");
+    const actual = linter.buildAnnotatedMarkdown(text);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/comments.json"), JSON.stringify(actual), "utf8");
+    assert.deepStrictEqual(actual, expected);
+  });
+
   test('Linter should return annotated text for Markdown with Front Matter (YAML)', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/front-matter.json"), "utf8"));
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/front-matter.md"), "utf8");

--- a/src/test/suite/linter.test.ts
+++ b/src/test/suite/linter.test.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import * as chai from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ConfigurationManager } from '../../common/configuration-manager';
@@ -20,7 +19,7 @@ suite('Linter Test Suite', () => {
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/backticks.md"), "utf8");
     const result = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/backticks.json"), JSON.stringify(result), "utf8");
-    assert.ok(chai.expect(result).to.deep.equal(expected));
+    assert.deepEqual(expected, result);
   });
 
   test('Linter should return annotated text for Markdown with Headers', () => {
@@ -28,7 +27,7 @@ suite('Linter Test Suite', () => {
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/headers.md"), "utf8");
     const result = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/headers.json"), JSON.stringify(result), "utf8");
-    assert.ok(chai.expect(result).to.deep.equal(expected));
+    assert.deepEqual(expected, result);
   });
 
   test('Linter should return annotated text for Markdown with Ordered Lists', () => {
@@ -36,7 +35,7 @@ suite('Linter Test Suite', () => {
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/ordered-lists.md"), "utf8");
     const result = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/ordered-lists.json"), JSON.stringify(result), "utf8");
-    assert.ok(chai.expect(result).to.deep.equal(expected));
+    assert.deepEqual(expected, result);
   });
 
   test('Linter should return annotated text for Markdown with Unordered Lists', () => {
@@ -44,7 +43,7 @@ suite('Linter Test Suite', () => {
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.md"), "utf8");
     const result = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.json"), JSON.stringify(result), "utf8");
-    assert.ok(chai.expect(result).to.deep.equal(expected));
+    assert.deepEqual(expected, result);
   });
 
   test('Linter should return annotated text for HTML', () => {
@@ -52,7 +51,7 @@ suite('Linter Test Suite', () => {
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.html"), "utf8");
     const result = linter.buildAnnotatedHTML(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), JSON.stringify(result), "utf8");
-    assert.ok(chai.expect(result).to.deep.equal(expected));
+    assert.deepEqual(expected, result);
   });
 
   test('Linter should return annotated text for Plaintext', () => {
@@ -60,7 +59,7 @@ suite('Linter Test Suite', () => {
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.txt"), "utf8");
     const result = linter.buildAnnotatedPlaintext(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.json"), JSON.stringify(result), "utf8");
-    assert.ok(chai.expect(result).to.deep.equal(expected));
+    assert.deepEqual(expected, result);
   });
 
   test('Linter should only smart format text in annotatedtext', () => {

--- a/src/test/suite/linter.test.ts
+++ b/src/test/suite/linter.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { ConfigurationManager } from '../../common/configuration-manager';
 import { Linter } from "../../linter/linter";
+import { IAnnotatedtext } from "../../linter/interfaces";
 
 suite('Linter Test Suite', () => {
 
@@ -15,32 +16,38 @@ suite('Linter Test Suite', () => {
   });
 
   test('Linter should return annotated text for Basic Markdown', () => {
-    const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/basic.json"), "utf8"));
-    const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/basic.md"), "utf8");
-    const result = linter.buildAnnotatedMarkdown(text);
-    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/basic.json"), JSON.stringify(result), "utf8");
-    assert.deepEqual(expected, result);
+    const expected: JSON = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/basic.json"), "utf8"));
+    const text: string = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/basic.md"), "utf8");
+    const actual: IAnnotatedtext = linter.buildAnnotatedMarkdown(text);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/basic.json"), JSON.stringify(actual), "utf8");
+    assert.deepStrictEqual(expected, actual);
   });
 
   test('Linter should return annotated text for HTML', () => {
-    const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), "utf8"));
-    const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.html"), "utf8");
-    const result = linter.buildAnnotatedHTML(text);
-    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), JSON.stringify(result), "utf8");
-    assert.deepEqual(expected, result);
+    const expected: JSON = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), "utf8"));
+    const text: string = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.html"), "utf8");
+    const actual: IAnnotatedtext = linter.buildAnnotatedHTML(text);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), JSON.stringify(actual), "utf8");
+    assert.deepStrictEqual(expected, actual);
   });
 
   test('Linter should return annotated text for Plaintext', () => {
-    const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.json"), "utf8"));
-    const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.txt"), "utf8");
-    const result = linter.buildAnnotatedPlaintext(text);
-    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.json"), JSON.stringify(result), "utf8");
-    assert.deepEqual(expected, result);
+    const expected: JSON = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.json"), "utf8"));
+    const text: string = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.txt"), "utf8");
+    const actual: IAnnotatedtext = linter.buildAnnotatedPlaintext(text);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.json"), JSON.stringify(actual), "utf8");
+    assert.deepStrictEqual(expected, actual);
   });
 
   test('Linter should only smart format text in annotatedtext', () => {
-    // TODO: Make a real test.
-    assert.ok(true);
+    const expected: string = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/smart-format-formatted.md"), "utf8");
+    const expectedJSON: JSON = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/smart-format-unformatted.json"), "utf8"));
+    const text: string = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/smart-format-unformatted.md"), "utf8");
+    const annotatedtext: IAnnotatedtext = linter.buildAnnotatedMarkdown(text);
+    assert.deepStrictEqual(annotatedtext, expectedJSON);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/smart-format-unformatted.json"), JSON.stringify(annotatedtext), "utf8");
+    const actual: string = linter.smartFormatAnnotatedtext(annotatedtext);
+    assert.equal(actual, expected);
   });
 
 });

--- a/src/test/suite/linter.test.ts
+++ b/src/test/suite/linter.test.ts
@@ -11,9 +11,9 @@ suite('Linter Test Suite', () => {
   const linter: Linter = new Linter(config);
   const testWorkspace: string = path.resolve(__dirname, "../../../src/test-fixtures/workspace");
 
-	test('Linter should instantiate', () => {
-		assert.ok(linter);
-	});
+  test('Linter should instantiate', () => {
+    assert.ok(linter);
+  });
 
   test('Linter should return annotated text for Markdown with Backticks', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/backticks.json"), "utf8"));
@@ -61,6 +61,11 @@ suite('Linter Test Suite', () => {
     const result = linter.buildAnnotatedPlaintext(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.json"), JSON.stringify(result), "utf8");
     assert.ok(chai.expect(result).to.deep.equal(expected));
+  });
+
+  test('Linter should only smart format text in annotatedtext', () => {
+    // TODO: Make a real test.
+    assert.ok(true);
   });
 
 });

--- a/src/test/suite/linter.test.ts
+++ b/src/test/suite/linter.test.ts
@@ -18,7 +18,7 @@ suite('Linter Test Suite', () => {
   test('Linter should return annotated text for Markdown with Backticks', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/backticks.json"), "utf8"));
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/backticks.md"), "utf8");
-    const result = JSON.parse(linter.buildAnnotatedMarkdown(text));
+    const result = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/backticks.json"), JSON.stringify(result), "utf8");
     assert.ok(chai.expect(result).to.deep.equal(expected));
   });
@@ -26,7 +26,7 @@ suite('Linter Test Suite', () => {
   test('Linter should return annotated text for Markdown with Headers', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/headers.json"), "utf8"));
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/headers.md"), "utf8");
-    const result = JSON.parse(linter.buildAnnotatedMarkdown(text));
+    const result = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/headers.json"), JSON.stringify(result), "utf8");
     assert.ok(chai.expect(result).to.deep.equal(expected));
   });
@@ -34,7 +34,7 @@ suite('Linter Test Suite', () => {
   test('Linter should return annotated text for Markdown with Ordered Lists', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/ordered-lists.json"), "utf8"));
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/ordered-lists.md"), "utf8");
-    const result = JSON.parse(linter.buildAnnotatedMarkdown(text));
+    const result = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/ordered-lists.json"), JSON.stringify(result), "utf8");
     assert.ok(chai.expect(result).to.deep.equal(expected));
   });
@@ -42,7 +42,7 @@ suite('Linter Test Suite', () => {
   test('Linter should return annotated text for Markdown with Unordered Lists', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.json"), "utf8"));
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.md"), "utf8");
-    const result = JSON.parse(linter.buildAnnotatedMarkdown(text));
+    const result = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.json"), JSON.stringify(result), "utf8");
     assert.ok(chai.expect(result).to.deep.equal(expected));
   });
@@ -50,7 +50,7 @@ suite('Linter Test Suite', () => {
   test('Linter should return annotated text for HTML', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), "utf8"));
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.html"), "utf8");
-    const result = JSON.parse(linter.buildAnnotatedHTML(text));
+    const result = linter.buildAnnotatedHTML(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), JSON.stringify(result), "utf8");
     assert.ok(chai.expect(result).to.deep.equal(expected));
   });
@@ -58,7 +58,7 @@ suite('Linter Test Suite', () => {
   test('Linter should return annotated text for Plaintext', () => {
     const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.json"), "utf8"));
     const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.txt"), "utf8");
-    const result = JSON.parse(linter.buildAnnotatedPlaintext(text));
+    const result = linter.buildAnnotatedPlaintext(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.json"), JSON.stringify(result), "utf8");
     assert.ok(chai.expect(result).to.deep.equal(expected));
   });

--- a/src/typeFormatters/dashesFormatter.ts
+++ b/src/typeFormatters/dashesFormatter.ts
@@ -40,7 +40,7 @@ export class DashesFormattingProvider implements vscode.OnTypeFormattingEditProv
     const prevCh: string = (position.character > 0) ? line.text.charAt(position.character - 2) : " ";
     const prevPrevCh: string = (position.character > 1) ? line.text.charAt(position.character - 3) : " ";
 
-    if (this.config.isSmartFormatEnabled()) {
+    if (this.config.isSmartFormatOnType()) {
       if (prevCh === DashesFormattingProvider.enDash) {
         return [new vscode.TextEdit(range, DashesFormattingProvider.emDash)];
       } else if (prevCh === DashesFormattingProvider.hyphen) {

--- a/src/typeFormatters/dashesFormatter.ts
+++ b/src/typeFormatters/dashesFormatter.ts
@@ -40,7 +40,7 @@ export class DashesFormattingProvider implements vscode.OnTypeFormattingEditProv
     const prevCh: string = (position.character > 0) ? line.text.charAt(position.character - 2) : " ";
     const prevPrevCh: string = (position.character > 1) ? line.text.charAt(position.character - 3) : " ";
 
-    if (this.config.isAutoFormatEnabled()) {
+    if (this.config.isSmartFormatEnabled()) {
       if (prevCh === DashesFormattingProvider.enDash) {
         return [new vscode.TextEdit(range, DashesFormattingProvider.emDash)];
       } else if (prevCh === DashesFormattingProvider.hyphen) {

--- a/src/typeFormatters/ellipsesFormatter.ts
+++ b/src/typeFormatters/ellipsesFormatter.ts
@@ -39,7 +39,7 @@ export class EllipsesFormattingProvider implements vscode.OnTypeFormattingEditPr
     const prevCh: string = (position.character > 0) ? line.text.charAt(position.character - 2) : " ";
     const prevPrevCh: string = (position.character > 1) ? line.text.charAt(position.character - 3) : " ";
 
-    if (this.config.isAutoFormatEnabled()) {
+    if (this.config.isSmartFormatEnabled()) {
       if (prevCh === EllipsesFormattingProvider.period && prevPrevCh === EllipsesFormattingProvider.period) {
         return [new vscode.TextEdit(range, EllipsesFormattingProvider.ellipses)];
       }

--- a/src/typeFormatters/ellipsesFormatter.ts
+++ b/src/typeFormatters/ellipsesFormatter.ts
@@ -39,7 +39,7 @@ export class EllipsesFormattingProvider implements vscode.OnTypeFormattingEditPr
     const prevCh: string = (position.character > 0) ? line.text.charAt(position.character - 2) : " ";
     const prevPrevCh: string = (position.character > 1) ? line.text.charAt(position.character - 3) : " ";
 
-    if (this.config.isSmartFormatEnabled()) {
+    if (this.config.isSmartFormatOnType()) {
       if (prevCh === EllipsesFormattingProvider.period && prevPrevCh === EllipsesFormattingProvider.period) {
         return [new vscode.TextEdit(range, EllipsesFormattingProvider.ellipses)];
       }

--- a/src/typeFormatters/quotesFormatter.ts
+++ b/src/typeFormatters/quotesFormatter.ts
@@ -43,7 +43,7 @@ export class QuotesFormattingProvider implements vscode.OnTypeFormattingEditProv
     const prevCh: string = (position.character > 1) ? line.text.charAt(position.character - 2) : " ";
     const nextCh: string = (position.character < line.text.length) ? line.text.charAt(line.text.length + 1) : " ";
 
-    if (this.config.isSmartFormatEnabled()) {
+    if (this.config.isSmartFormatOnType()) {
       switch (ch) {
         case QuotesFormattingProvider.doubleQuote:
           if (prevCh === " ") {

--- a/src/typeFormatters/quotesFormatter.ts
+++ b/src/typeFormatters/quotesFormatter.ts
@@ -43,7 +43,7 @@ export class QuotesFormattingProvider implements vscode.OnTypeFormattingEditProv
     const prevCh: string = (position.character > 1) ? line.text.charAt(position.character - 2) : " ";
     const nextCh: string = (position.character < line.text.length) ? line.text.charAt(line.text.length + 1) : " ";
 
-    if (this.config.isAutoFormatEnabled()) {
+    if (this.config.isSmartFormatEnabled()) {
       switch (ch) {
         case QuotesFormattingProvider.doubleQuote:
           if (prevCh === " ") {


### PR DESCRIPTION
Renamed "auto format" to "smart format" to align with what it really does. Smart format command now uses and annotatedtext object to only apply formatting  to text and skip markup.