### PR TITLE
Do not force switch to the LT_OUTPUT_CHANNEL on errors

### DIFF
--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -243,7 +243,6 @@ export class Linter implements CodeActionProvider {
         .catch((err) => {
           LT_OUTPUT_CHANNEL.appendLine("Error connecting to " + url);
           LT_OUTPUT_CHANNEL.appendLine(err);
-          LT_OUTPUT_CHANNEL.show(true);
         });
     } else {
       LT_OUTPUT_CHANNEL.appendLine("No LanguageTool URL provided. Please check your settings and try again.");


### PR DESCRIPTION
The extension switches to the output channel view on every error. This is annoying as it takes away the focus of the terminal or the problems view, which are often much more useful.
Moreover, the errors are not always real errors. There are at least three cases which are mostly benign:
* The server is unreachable because it is not yet started.
* The server choked on the input and returned an error because the checking produces a too high failure rate.
* The server runs into a timeout.