### PR TITLE
Escape Characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes not yet released.
 
+## [0.14.0] - 2020-05-09
+
+### Fixed
+
+* Backslashes in markdown plus a valid escape character no longer shifting diagnostic highlighting [#132](https://github.com/davidlday/vscode-languagetool-linter/issues/132)
+
 ## [0.13.0] - 2020-05-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LanguageTool Linter for Visual Studio Code
 
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/davidlday/vscode-languagetool-linter/Node.js%20CI)](https://github.com/davidlday/vscode-languagetool-linter/actions)
+[![Node.js CI](https://github.com/davidlday/vscode-languagetool-linter/workflows/Node.js%20CI/badge.svg)](https://github.com/davidlday/vscode-languagetool-linter/actions?query=workflow%3A%22Node.js+CI%22)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1f9fb350738a438ba0d4142896733026)](https://www.codacy.com/manual/davidlday/vscode-languagetool-linter?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=davidlday/vscode-languagetool-linter&amp;utm_campaign=Badge_Grade)
 [![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/davidlday.languagetool-linter?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=davidlday.languagetool-linter)
 [![Visual Studio Marketplace Rating (Stars)](https://img.shields.io/visual-studio-marketplace/stars/davidlday.languagetool-linter?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=davidlday.languagetool-linter)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # LanguageTool Linter for Visual Studio Code
 
+<!--
+NOTE: SVGs not allowed in README on extensions.
 [![Node.js CI](https://github.com/davidlday/vscode-languagetool-linter/workflows/Node.js%20CI/badge.svg)](https://github.com/davidlday/vscode-languagetool-linter/actions?query=workflow%3A%22Node.js+CI%22)
+-->
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/davidlday/vscode-languagetool-linter/Node.js%20CI)](https://github.com/davidlday/vscode-languagetool-linter/actions)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1f9fb350738a438ba0d4142896733026)](https://www.codacy.com/manual/davidlday/vscode-languagetool-linter?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=davidlday/vscode-languagetool-linter&amp;utm_campaign=Badge_Grade)
 [![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/davidlday.languagetool-linter?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=davidlday.languagetool-linter)
 [![Visual Studio Marketplace Rating (Stars)](https://img.shields.io/visual-studio-marketplace/stars/davidlday.languagetool-linter?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=davidlday.languagetool-linter)

--- a/package-lock.json
+++ b/package-lock.json
@@ -424,44 +424,36 @@
       "dev": true
     },
     "annotatedtext": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/annotatedtext/-/annotatedtext-0.1.1.tgz",
-      "integrity": "sha512-xWMO3zLONEu+k+X9cNV7MSWFLT1AQ7eKPirpGcu1QLsoOMOUs7VNWmc0Hj7Tr1HICHgRjaQbDEW8Z1/1RGwnUw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/annotatedtext/-/annotatedtext-0.2.0.tgz",
+      "integrity": "sha512-Dets4dEqFP6IzbCUg09BQm+cxFfSGmpptVhWqbrRBkC1aj1vUZ9RHCGBG5NZz4BuRd7JtPnoAv7aTi8K7RNX3Q=="
     },
     "annotatedtext-rehype": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/annotatedtext-rehype/-/annotatedtext-rehype-0.1.3.tgz",
-      "integrity": "sha512-t3n0K1Z3FnC6KWdsKLUBYPdw7PyNjEBgi73GM7zp1uoxbxacmccIv3PocCdGrJoCm8wmQLkH7bqzv6Ba0qgVzg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/annotatedtext-rehype/-/annotatedtext-rehype-0.2.0.tgz",
+      "integrity": "sha512-jmyna3w9w83i/A+7BI3Xq7DlOn+QsYCz1Ime3dp5R2TsEBH2hk18AajMhHShSM8J5teKDgJZin3RmQP8zewkGg==",
       "requires": {
-        "annotatedtext": "^0.1.1",
+        "annotatedtext": "^0.2.0",
         "rehype-parse": "^6.0.0",
-        "unified": "^9.0.0"
-      }
-    },
-    "annotatedtext-remark": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/annotatedtext-remark/-/annotatedtext-remark-0.4.1.tgz",
-      "integrity": "sha512-VBWzSHGcjh5Myk0WQxBYFhMFvvigQuXZkRSk0iM/rtuEyqDCEWWwT5x83QxD/+XR/tR5i/hU+ighLRvgYRgGCg==",
-      "requires": {
-        "annotatedtext": "^0.1.1",
-        "remark-frontmatter": "^2.0.0",
-        "remark-parse": "^8.0.0",
         "unified": "^9.0.0"
       },
       "dependencies": {
-        "unified": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-9.0.0.tgz",
-          "integrity": "sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==",
-          "requires": {
-            "bail": "^1.0.0",
-            "extend": "^3.0.0",
-            "is-buffer": "^2.0.0",
-            "is-plain-obj": "^2.0.0",
-            "trough": "^1.0.0",
-            "vfile": "^4.0.0"
-          }
+        "annotatedtext": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/annotatedtext/-/annotatedtext-0.2.0.tgz",
+          "integrity": "sha512-Dets4dEqFP6IzbCUg09BQm+cxFfSGmpptVhWqbrRBkC1aj1vUZ9RHCGBG5NZz4BuRd7JtPnoAv7aTi8K7RNX3Q=="
         }
+      }
+    },
+    "annotatedtext-remark": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/annotatedtext-remark/-/annotatedtext-remark-0.5.0.tgz",
+      "integrity": "sha512-sxX9RwNWCTL08MCLsPl715wmPlVdjr8EtD8oXsoZHNaf1TiszfaEvo3HAJyx6nLfJVhc/ETfBxBglmbn6YrKOw==",
+      "requires": {
+        "annotatedtext": "^0.2.0",
+        "remark-frontmatter": "^2.0.0",
+        "remark-parse": "^8.0.0",
+        "unified": "^9.0.0"
       }
     },
     "ansi-colors": {

--- a/package.json
+++ b/package.json
@@ -412,8 +412,8 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "annotatedtext-rehype": "^0.1.3",
-    "annotatedtext-remark": "^0.4.1",
+    "annotatedtext-rehype": "^0.2.0",
+    "annotatedtext-remark": "^0.5.0",
     "execa": "^4.0.0",
     "glob": "^7.1.6",
     "portfinder": "^1.0.26",

--- a/src/test-fixtures/workspace/html/escape-character.html
+++ b/src/test-fixtures/workspace/html/escape-character.html
@@ -1,0 +1,10 @@
+<h1 id="backslash--special-char--shifted-highlight">Backslash + Special Char = Shifted Highlight</h1>
+<p>This is a inccoreect sentence.</p>
+<p>Here is the culprit: \-.</p>
+<p>This is annother incorrect sentence.</p>
+<p>Here is another culprit: \;.</p>
+<p>This is annother incorrect sentence.</p>
+<ul>
+<li>Is this yet another?</li>
+</ul>
+<p>This is annother incorrect sentence.</p>

--- a/src/test-fixtures/workspace/html/escape-character.json
+++ b/src/test-fixtures/workspace/html/escape-character.json
@@ -1,0 +1,282 @@
+{
+  "annotation": [
+    {
+      "markup": "<h1 id=\"backslash--special-char--shifted-highlight\">",
+      "interpretAs": "",
+      "offset": {
+        "start": 0,
+        "end": 52
+      }
+    },
+    {
+      "text": "Backslash + Special Char = Shifted Highlight",
+      "offset": {
+        "start": 52,
+        "end": 96
+      }
+    },
+    {
+      "markup": "</h1>",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 96,
+        "end": 101
+      }
+    },
+    {
+      "text": "\n",
+      "offset": {
+        "start": 101,
+        "end": 102
+      }
+    },
+    {
+      "markup": "<p>",
+      "interpretAs": "",
+      "offset": {
+        "start": 102,
+        "end": 105
+      }
+    },
+    {
+      "text": "This is a inccoreect sentence.",
+      "offset": {
+        "start": 105,
+        "end": 135
+      }
+    },
+    {
+      "markup": "</p>",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 135,
+        "end": 139
+      }
+    },
+    {
+      "text": "\n",
+      "offset": {
+        "start": 139,
+        "end": 140
+      }
+    },
+    {
+      "markup": "<p>",
+      "interpretAs": "",
+      "offset": {
+        "start": 140,
+        "end": 143
+      }
+    },
+    {
+      "text": "Here is the culprit: \\-.",
+      "offset": {
+        "start": 143,
+        "end": 167
+      }
+    },
+    {
+      "markup": "</p>",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 167,
+        "end": 171
+      }
+    },
+    {
+      "text": "\n",
+      "offset": {
+        "start": 171,
+        "end": 172
+      }
+    },
+    {
+      "markup": "<p>",
+      "interpretAs": "",
+      "offset": {
+        "start": 172,
+        "end": 175
+      }
+    },
+    {
+      "text": "This is annother incorrect sentence.",
+      "offset": {
+        "start": 175,
+        "end": 211
+      }
+    },
+    {
+      "markup": "</p>",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 211,
+        "end": 215
+      }
+    },
+    {
+      "text": "\n",
+      "offset": {
+        "start": 215,
+        "end": 216
+      }
+    },
+    {
+      "markup": "<p>",
+      "interpretAs": "",
+      "offset": {
+        "start": 216,
+        "end": 219
+      }
+    },
+    {
+      "text": "Here is another culprit: \\;.",
+      "offset": {
+        "start": 219,
+        "end": 247
+      }
+    },
+    {
+      "markup": "</p>",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 247,
+        "end": 251
+      }
+    },
+    {
+      "text": "\n",
+      "offset": {
+        "start": 251,
+        "end": 252
+      }
+    },
+    {
+      "markup": "<p>",
+      "interpretAs": "",
+      "offset": {
+        "start": 252,
+        "end": 255
+      }
+    },
+    {
+      "text": "This is annother incorrect sentence.",
+      "offset": {
+        "start": 255,
+        "end": 291
+      }
+    },
+    {
+      "markup": "</p>",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 291,
+        "end": 295
+      }
+    },
+    {
+      "text": "\n",
+      "offset": {
+        "start": 295,
+        "end": 296
+      }
+    },
+    {
+      "markup": "<ul>",
+      "interpretAs": "",
+      "offset": {
+        "start": 296,
+        "end": 300
+      }
+    },
+    {
+      "text": "\n",
+      "offset": {
+        "start": 300,
+        "end": 301
+      }
+    },
+    {
+      "markup": "<li>",
+      "interpretAs": "",
+      "offset": {
+        "start": 301,
+        "end": 305
+      }
+    },
+    {
+      "text": "Is this yet another?",
+      "offset": {
+        "start": 305,
+        "end": 325
+      }
+    },
+    {
+      "markup": "</li>",
+      "interpretAs": "",
+      "offset": {
+        "start": 325,
+        "end": 330
+      }
+    },
+    {
+      "text": "\n",
+      "offset": {
+        "start": 330,
+        "end": 331
+      }
+    },
+    {
+      "markup": "</ul>",
+      "interpretAs": "",
+      "offset": {
+        "start": 331,
+        "end": 336
+      }
+    },
+    {
+      "text": "\n",
+      "offset": {
+        "start": 336,
+        "end": 337
+      }
+    },
+    {
+      "markup": "<p>",
+      "interpretAs": "",
+      "offset": {
+        "start": 337,
+        "end": 340
+      }
+    },
+    {
+      "text": "This is annother incorrect sentence.",
+      "offset": {
+        "start": 340,
+        "end": 376
+      }
+    },
+    {
+      "markup": "</p>",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 376,
+        "end": 380
+      }
+    },
+    {
+      "text": "\n",
+      "offset": {
+        "start": 380,
+        "end": 381
+      }
+    },
+    {
+      "markup": "",
+      "interpretAs": "",
+      "offset": {
+        "start": 381,
+        "end": 381
+      }
+    }
+  ]
+}

--- a/src/test-fixtures/workspace/markdown/escape-character.json
+++ b/src/test-fixtures/workspace/markdown/escape-character.json
@@ -1,0 +1,192 @@
+{
+  "annotation": [
+    {
+      "markup": "# ",
+      "interpretAs": "",
+      "offset": {
+        "start": 0,
+        "end": 2
+      }
+    },
+    {
+      "text": "Backslash + Special Char = Shifted Highlight",
+      "offset": {
+        "start": 2,
+        "end": 46
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 46,
+        "end": 48
+      }
+    },
+    {
+      "text": "This is a inccoreect sentence.",
+      "offset": {
+        "start": 48,
+        "end": 78
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 78,
+        "end": 80
+      }
+    },
+    {
+      "text": "Here is the culprit: ",
+      "offset": {
+        "start": 80,
+        "end": 101
+      }
+    },
+    {
+      "markup": "",
+      "interpretAs": "",
+      "offset": {
+        "start": 101,
+        "end": 101
+      }
+    },
+    {
+      "text": "\\-",
+      "offset": {
+        "start": 101,
+        "end": 103
+      }
+    },
+    {
+      "markup": "",
+      "interpretAs": "",
+      "offset": {
+        "start": 103,
+        "end": 103
+      }
+    },
+    {
+      "text": ".",
+      "offset": {
+        "start": 103,
+        "end": 104
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 104,
+        "end": 106
+      }
+    },
+    {
+      "text": "This is annother incorrect sentence.",
+      "offset": {
+        "start": 106,
+        "end": 142
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 142,
+        "end": 144
+      }
+    },
+    {
+      "text": "Here is another culprit: ",
+      "offset": {
+        "start": 144,
+        "end": 169
+      }
+    },
+    {
+      "markup": "",
+      "interpretAs": "",
+      "offset": {
+        "start": 169,
+        "end": 169
+      }
+    },
+    {
+      "text": "\\;",
+      "offset": {
+        "start": 169,
+        "end": 171
+      }
+    },
+    {
+      "markup": "",
+      "interpretAs": "",
+      "offset": {
+        "start": 171,
+        "end": 171
+      }
+    },
+    {
+      "text": ".",
+      "offset": {
+        "start": 171,
+        "end": 172
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 172,
+        "end": 174
+      }
+    },
+    {
+      "text": "This is annother incorrect sentence.",
+      "offset": {
+        "start": 174,
+        "end": 210
+      }
+    },
+    {
+      "markup": "\n\n* ",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 210,
+        "end": 214
+      }
+    },
+    {
+      "text": "Is this yet another?",
+      "offset": {
+        "start": 214,
+        "end": 234
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 234,
+        "end": 236
+      }
+    },
+    {
+      "text": "This is annother incorrect sentence.",
+      "offset": {
+        "start": 236,
+        "end": 272
+      }
+    },
+    {
+      "markup": "\n",
+      "interpretAs": "\n",
+      "offset": {
+        "start": 272,
+        "end": 273
+      }
+    }
+  ]
+}

--- a/src/test-fixtures/workspace/markdown/escape-character.json
+++ b/src/test-fixtures/workspace/markdown/escape-character.json
@@ -2,7 +2,7 @@
   "annotation": [
     {
       "markup": "# ",
-      "interpretAs": "",
+      "interpretAs": "# ",
       "offset": {
         "start": 0,
         "end": 2
@@ -152,7 +152,7 @@
     },
     {
       "markup": "\n\n* ",
-      "interpretAs": "\n\n",
+      "interpretAs": "\n\n* ",
       "offset": {
         "start": 210,
         "end": 214

--- a/src/test-fixtures/workspace/markdown/escape-character.md
+++ b/src/test-fixtures/workspace/markdown/escape-character.md
@@ -1,0 +1,15 @@
+# Backslash + Special Char = Shifted Highlight
+
+This is a inccoreect sentence.
+
+Here is the culprit: \-.
+
+This is annother incorrect sentence.
+
+Here is another culprit: \;.
+
+This is annother incorrect sentence.
+
+* Is this yet another?
+
+This is annother incorrect sentence.

--- a/src/test/suite/linter.html.test.ts
+++ b/src/test/suite/linter.html.test.ts
@@ -1,0 +1,34 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import { ConfigurationManager } from "../../configuration/manager";
+import { IAnnotatedtext } from "../../linter/interfaces";
+import { Linter } from "../../linter/linter";
+
+suite("Linter HTML Test Suite", () => {
+
+  const config: ConfigurationManager = new ConfigurationManager();
+  const linter: Linter = new Linter(config);
+  const testWorkspace: string = path.resolve(__dirname, "../../../src/test-fixtures/workspace");
+
+  test("Linter should instantiate", () => {
+    assert.ok(linter);
+  });
+
+  test("Linter should return annotated text for HTML", () => {
+    const expected: JSON = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), "utf8"));
+    const text: string = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.html"), "utf8");
+    const actual: IAnnotatedtext = linter.buildAnnotatedHTML(text);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), JSON.stringify(actual), "utf8");
+    assert.deepStrictEqual(expected, actual);
+  });
+
+  test("Linter should return annotated text for HTML with Escape Characters (\\)", () => {
+    const expected: JSON = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/html/escape-character.json"), "utf8"));
+    const text: string = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/html/escape-character.html"), "utf8");
+    const actual: IAnnotatedtext = linter.buildAnnotatedHTML(text);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), JSON.stringify(actual), "utf8");
+    assert.deepStrictEqual(expected, actual);
+  });
+
+});

--- a/src/test/suite/linter.markdown.test.ts
+++ b/src/test/suite/linter.markdown.test.ts
@@ -70,4 +70,12 @@ suite("Linter Markdown Test Suite", () => {
     assert.deepStrictEqual(actual, expected);
   });
 
+  test("Linter should return annotated text for Markdown with Escape Characters (\\)", () => {
+    const expected = JSON.parse(fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/escape-character.json"), "utf8"));
+    const text = fs.readFileSync(path.resolve(__dirname, testWorkspace + "/markdown/escape-character.md"), "utf8");
+    const actual = linter.buildAnnotatedMarkdown(text);
+    // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.json"), JSON.stringify(actual), "utf8");
+    assert.deepStrictEqual(actual, expected);
+  });
+
 });


### PR DESCRIPTION
Updated underlying libraries (`annotatedtext-remark`, `annotatedtext-rehype`, `annotatedtext`) to source text node values directly from the document instead of accepting the parsers view.

Closes #132 