### PR TITLE
Specify Language IDs to Consider "Plain Text"

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "proseWrap": "always"
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "proseWrap": "always"
+  "proseWrap": "always",
+  "trailingComma": "all"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,220 +1,299 @@
 # Change Log
 
-All notable changes to the “languagetool-linter” extension will be documented in this file.
+All notable changes to the “languagetool-linter” extension will be documented in
+this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 Changes not yet released.
 
+### Added
+
+- Ability to enable / disable checking of Plain Text documents. Enabled by
+  default.
+- Ability to provide a list of
+  [language ids](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers)
+  that should be considered Plain Text. Defaults to “plaintext”.
+- “Force Check as Plain Text Document” command shows on all language ids other
+  than HTML and Markdown for manual, one-time checking.
+- “Clear Document Diagnostics” command to clear LanguageTool diagnostics in
+  support of one-time checking.
+
+### Changed
+
+- Relabeled “Lint Current Document” command to “Check Document”.
+- Only HTML and Markdown show the “Check Document” command.
+
 ### Maintenance
 
-* updated dependencies
-* prettier code
+- updated dependencies
+- prettier code
 
 ### Security
 
-* npm audit fix
+- npm audit fix
 
 ## [0.14.0] - 2020-05-09
 
 ### Fixed
 
-* Backslashes in markdown plus a valid escape character no longer shifting diagnostic highlighting [#132](https://github.com/davidlday/vscode-languagetool-linter/issues/132)
+- Backslashes in markdown plus a valid escape character no longer shifting
+  diagnostic highlighting
+  [#132](https://github.com/davidlday/vscode-languagetool-linter/issues/132)
 
 ## [0.13.0] - 2020-05-08
 
 ### Fixed
 
-* Keyboard shortcuts and light bulb now working on LanguageTool problems [#120](https://github.com/davidlday/vscode-languagetool-linter/issues/120)
+- Keyboard shortcuts and light bulb now working on LanguageTool problems
+  [#120](https://github.com/davidlday/vscode-languagetool-linter/issues/120)
 
 ## [0.12.1] - 2020-05-07
 
 ### Changed
 
-* Testing release via GitHub Actions
+- Testing release via GitHub Actions
 
 ## [0.12.0] - 2020-01-26
 
 ### Changed
 
-* Output channel no longer forced open on errors
-* Ignored Word Configuration items specified as strings
-* Refactored constants and configuration manager
+- Output channel no longer forced open on errors
+- Ignored Word Configuration items specified as strings
+- Refactored constants and configuration manager
 
 ## [0.11.0] - 2020-01-11
 
 ### Fixed
 
-* Smart Format command name updated
-* TSLint configuration updated
-* Codacy checks use repo configuration
-* Reduced unnecessary linting by removing `onDidChangeActiveTextEditor` subscription and only subscribing to `onDidChangeTextDocument`
-* Diagnostics cleared when document is closed to eliminate messages appearing after document is closed [#64](https://github.com/davidlday/vscode-languagetool-linter/issues/64)
-* Smart Format on Save no longer appending newline at end [#81](https://github.com/davidlday/vscode-languagetool-linter/issues/81)
-* Conditions for smart double quotes [#84](https://github.com/davidlday/vscode-languagetool-linter/issues/84)
+- Smart Format command name updated
+- TSLint configuration updated
+- Codacy checks use repo configuration
+- Reduced unnecessary linting by removing `onDidChangeActiveTextEditor`
+  subscription and only subscribing to `onDidChangeTextDocument`
+- Diagnostics cleared when document is closed to eliminate messages appearing
+  after document is closed
+  [#64](https://github.com/davidlday/vscode-languagetool-linter/issues/64)
+- Smart Format on Save no longer appending newline at end
+  [#81](https://github.com/davidlday/vscode-languagetool-linter/issues/81)
+- Conditions for smart double quotes
+  [#84](https://github.com/davidlday/vscode-languagetool-linter/issues/84)
 
 ### Added
 
-* Smart Format on Save option
-* Lint on Save setting [#80](https://github.com/davidlday/vscode-languagetool-linter/issues/80)
-* Lint on Open setting [#80](https://github.com/davidlday/vscode-languagetool-linter/issues/80)
-* Diagnostic Severity setting [#79](https://github.com/davidlday/vscode-languagetool-linter/issues/79)
-* Webpack for performance goodness
-* Hide Diagnostics on Change clears when document changes to hide messages while typing
-* Minimum and maximum port settings for the managed service [#78](https://github.com/davidlday/vscode-languagetool-linter/issues/78)
+- Smart Format on Save option
+- Lint on Save setting
+  [#80](https://github.com/davidlday/vscode-languagetool-linter/issues/80)
+- Lint on Open setting
+  [#80](https://github.com/davidlday/vscode-languagetool-linter/issues/80)
+- Diagnostic Severity setting
+  [#79](https://github.com/davidlday/vscode-languagetool-linter/issues/79)
+- Webpack for performance goodness
+- Hide Diagnostics on Change clears when document changes to hide messages while
+  typing
+- Minimum and maximum port settings for the managed service
+  [#78](https://github.com/davidlday/vscode-languagetool-linter/issues/78)
 
 ## [0.10.0] - 2019-12-07
 
 ### Fixed
 
-* Header marks reduced to only single hash instead of entire markup to prevent passing front matter
-* Smart Format command only applies smart format to text and skips markup
+- Header marks reduced to only single hash instead of entire markup to prevent
+  passing front matter
+- Smart Format command only applies smart format to text and skips markup
 
 ### Changed
 
-* Auto Format Enabled renamed to Smart Format on Type since it only formats smart characters
+- Auto Format Enabled renamed to Smart Format on Type since it only formats
+  smart characters
 
 ## [0.9.1] - 2019-12-01
 
 ### Fixed
 
-* Header marks (#) preserved to prevent LanguageTool from throwing `PUNCTUATION_PARAGRAPH_END` Errors
-* Ordered and Unordered list items interpreted as bullets to prevent LanguageTool from throwing `UPPERCASE_SENTENCE_START` and `PUNCTUATION_PARAGRAPH_END` Errors
-* Plaintext Annotatedtext produced correctly
+- Header marks (#) preserved to prevent LanguageTool from throwing
+  `PUNCTUATION_PARAGRAPH_END` Errors
+- Ordered and Unordered list items interpreted as bullets to prevent
+  LanguageTool from throwing `UPPERCASE_SENTENCE_START` and
+  `PUNCTUATION_PARAGRAPH_END` Errors
+- Plaintext Annotatedtext produced correctly
 
 ## [0.9.0] - 2019-11-29
 
 ### Added
 
-* Ignored Words lists at the User and Workspace levels.
-  * The Workspace level list appears in the User settings, but is ignored. This is due to how settings work as overrides instead of cumulative.
-  * Ignored words have an optional hint shown to remove the word from the ignored list.
+- Ignored Words lists at the User and Workspace levels.
+  - The Workspace level list appears in the User settings, but is ignored. This
+    is due to how settings work as overrides instead of cumulative.
+  - Ignored words have an optional hint shown to remove the word from the
+    ignored list.
 
 ## [0.8.1] - 2019-11-17
 
 ### Fixed
 
-* Corrected category on commands.
+- Corrected category on commands.
 
 ## [0.8.0] - 2019-11-17
 
 ### Added
 
-* `managed.classPath` setting supports multiple paths and file globbing via [node-glob](https://github.com/isaacs/node-glob). This accommodates various install methods. For example, on Arch Linux using the pacman LanguageTool package, you would set this to `/usr/share/java/languagetool/*.jar`.
+- `managed.classPath` setting supports multiple paths and file globbing via
+  [node-glob](https://github.com/isaacs/node-glob). This accommodates various
+  install methods. For example, on Arch Linux using the pacman LanguageTool
+  package, you would set this to `/usr/share/java/languagetool/*.jar`.
 
 ### Deprecated
 
-* Deprecated `managed.jarFile` setting in favor of `managed.classPath` to align with how the setting was used.
+- Deprecated `managed.jarFile` setting in favor of `managed.classPath` to align
+  with how the setting was used.
 
 ## [0.7.0] - 2019-11-17
 
 ### Deleted
 
-* New class path setting. Extension doesn’t activate when published, but all tests pass.
+- New class path setting. Extension doesn’t activate when published, but all
+  tests pass.
 
 ## [0.6.0] - 2019-11-17
 
 ### Added
 
-* `managed.classPath` setting supports multiple paths and file globbing via [node-glob](https://github.com/isaacs/node-glob). This accommodates various install methods. For example, on Arch Linux using the pacman LanguageTool package, you would set this to `/usr/share/java/languagetool/*.jar`.
+- `managed.classPath` setting supports multiple paths and file globbing via
+  [node-glob](https://github.com/isaacs/node-glob). This accommodates various
+  install methods. For example, on Arch Linux using the pacman LanguageTool
+  package, you would set this to `/usr/share/java/languagetool/*.jar`.
 
 ### Deprecated
 
-* Deprecated `managed.jarFile` setting in favor of `managed.classPath` to align with how the setting was used.
+- Deprecated `managed.jarFile` setting in favor of `managed.classPath` to align
+  with how the setting was used.
 
 ## [0.5.0] - 2019-11-15
 
 ### Fixed
 
-* Inline code is interpreted as hashtags, eliminated errors around extra spaces or missing words. ([#40](https://github.com/davidlday/vscode-languagetool-linter/issues/40))
+- Inline code is interpreted as hashtags, eliminated errors around extra spaces
+  or missing words.
+  ([#40](https://github.com/davidlday/vscode-languagetool-linter/issues/40))
 
 ### Added
 
-* Basic tests for extension, configuration manager, and linter.
+- Basic tests for extension, configuration manager, and linter.
 
 ## [0.4.1] - 2019-11-15
 
 ### Removed
 
-* All version 0.4.0 changes. Package broke on publication.
+- All version 0.4.0 changes. Package broke on publication.
 
 ## [0.4.0] - 2019-11-15
 
 ### Fixed
 
-* Inline code is interpreted as hashtags, eliminated errors around extra spaces or missing words. ([#40](https://github.com/davidlday/vscode-languagetool-linter/issues/40))
+- Inline code is interpreted as hashtags, eliminated errors around extra spaces
+  or missing words.
+  ([#40](https://github.com/davidlday/vscode-languagetool-linter/issues/40))
 
 ### Added
 
-* `managed.classPath` setting supports multiple paths and file globbing via [node-glob](https://github.com/isaacs/node-glob). This accommodates various install methods. For example, on Arch Linux using the pacman LanguageTool package, you would set this to `/usr/share/java/languagetool/*.jar`.
+- `managed.classPath` setting supports multiple paths and file globbing via
+  [node-glob](https://github.com/isaacs/node-glob). This accommodates various
+  install methods. For example, on Arch Linux using the pacman LanguageTool
+  package, you would set this to `/usr/share/java/languagetool/*.jar`.
 
 ### Deprecated
 
-* Deprecated `managed.jarFile` setting in favor of `managed.classPath` to align with how the setting was used.
+- Deprecated `managed.jarFile` setting in favor of `managed.classPath` to align
+  with how the setting was used.
 
 ## [0.3.2] - 2019-11-04
 
 ### Fixed
 
-* `autoFormatCommand` no longer eats the quotes at start of line
-* `autoFormatCommand` no longer converts comments to em-dashes
+- `autoFormatCommand` no longer eats the quotes at start of line
+- `autoFormatCommand` no longer converts comments to em-dashes
 
 ### Changed
 
-* Use regex in `autoFormatCommand` for simplicity.
+- Use regex in `autoFormatCommand` for simplicity.
 
 ## [0.3.1] - 2019-10-25
 
 ### Fixed
 
-* Upgraded http-proxy-agent to 2.2.3. ([npmjs advisory 1184](https://www.npmjs.com/advisories/1184))
+- Upgraded http-proxy-agent to 2.2.3.
+  ([npmjs advisory 1184](https://www.npmjs.com/advisories/1184))
 
 ## [0.3.0] - 2019-10-20
 
 ### Added
 
-* Auto Format on Type feature. Replaces double and single quotes with smart quotes, apostrophes with smart apostrophe, multiple consecutive hyphens with em and en dashes, and three consecutive periods with ellipses. Feature is controlled with `autoformat.enabled` setting.
-* Auto Format Command replaces quotes, apostrophes, dashes, and periods with smart quotes, en-dash, em-dash, and ellipses in the entire document.
+- Auto Format on Type feature. Replaces double and single quotes with smart
+  quotes, apostrophes with smart apostrophe, multiple consecutive hyphens with
+  em and en dashes, and three consecutive periods with ellipses. Feature is
+  controlled with `autoformat.enabled` setting.
+- Auto Format Command replaces quotes, apostrophes, dashes, and periods with
+  smart quotes, en-dash, em-dash, and ellipses in the entire document.
 
 ### Fixed
 
-* Updated annotatedtext-remark to filter out front matter.
+- Updated annotatedtext-remark to filter out front matter.
 
 ## [0.2.1] - 2019-10-06
 
 ### Fixed
 
-* Checking occurred on non-file documents (i.e. git). Lint functions now check to make sure documents passed in have a [URI](https://code.visualstudio.com/api/references/vscode-api#Uri) schema of “file”. See [issue #9](https://github.com/davidlday/vscode-languagetool-linter/issues/9).
+- Checking occurred on non-file documents (i.e. git). Lint functions now check
+  to make sure documents passed in have a
+  [URI](https://code.visualstudio.com/api/references/vscode-api#Uri) schema of
+  “file”. See
+  [issue #9](https://github.com/davidlday/vscode-languagetool-linter/issues/9).
 
 ## [0.2.0] - 2019-10-05
 
 ### Added
 
-* “Service Type” setting with the following 3 options:
-  * `external` (default): Use an external LanguageTool service. URL must be provided in “External: URL”.
-  * **NEW**: `managed`: Have VS Code manage a LanguageTool service. A path to a languagetool-server.jar file must be provided in “Managed: Jar File”. The extension will try to find a random open port.
-  * `public`: Uses the public LanguageTool API service.
+- “Service Type” setting with the following 3 options:
+  - `external` (default): Use an external LanguageTool service. URL must be
+    provided in “External: URL”.
+  - **NEW**: `managed`: Have VS Code manage a LanguageTool service. A path to a
+    languagetool-server.jar file must be provided in “Managed: Jar File”. The
+    extension will try to find a random open port.
+  - `public`: Uses the public LanguageTool API service.
 
 ### Changed
 
-* **BREAKING:** The checkbox setting “Public Api” has been replaced by the “Service Type” drop-down setting.
-* **BREAKING:** The “URL” setting has been moved to “External: URL”.
-* The caution notice for “Lint on Change” has been removed. Throttling seems to be working. Still off by default.
-* Output / errors now sent to “LanguageTool Linter” output channel.
+- **BREAKING:** The checkbox setting “Public Api” has been replaced by the
+  “Service Type” drop-down setting.
+- **BREAKING:** The “URL” setting has been moved to “External: URL”.
+- The caution notice for “Lint on Change” has been removed. Throttling seems to
+  be working. Still off by default.
+- Output / errors now sent to “LanguageTool Linter” output channel.
 
 ## [0.1.0] - 2019-09-28
 
 ### Added
 
-* Basic Spelling / Grammar Checking with Quick Fix options on errors.
-* `languageTool.disableCategories`: IDs of categories to be disabled, comma-separated.
-* `languageTool.disabledRules`: IDs of rules to be disabled, comma-separated.
-* `languageTool.language`: A language code like en-US, de-DE, fr, or auto to guess the language automatically (see `preferredVariants` below). For languages with variants (English, German, Portuguese) spell checking will only be activated when you specify the variant, e.g. en-GB instead of just en.
-* `languageTool.motherTongue`: A language code of the user‘s native language, enabling false friends checks for some language pairs.
-* `languageTool.preferredVariants`: Comma-separated list of preferred language variants. The language detector used with language=auto can detect e.g. English, but it cannot decide whether British English or American English is used. Thus, this parameter can be used to specify the preferred variants like en-GB and de-AT. Only available with language=auto.
-* `lintOnChange`: Lint every time the document changes. Use with caution.
-* `publicApi`: Use the public LanguageTool API Service.
-* `url`: URL of your LanguageTool server. Defaults to localhost on port 8081.
+- Basic Spelling / Grammar Checking with Quick Fix options on errors.
+- `languageTool.disableCategories`: IDs of categories to be disabled,
+  comma-separated.
+- `languageTool.disabledRules`: IDs of rules to be disabled, comma-separated.
+- `languageTool.language`: A language code like en-US, de-DE, fr, or auto to
+  guess the language automatically (see `preferredVariants` below). For
+  languages with variants (English, German, Portuguese) spell checking will only
+  be activated when you specify the variant, e.g. en-GB instead of just en.
+- `languageTool.motherTongue`: A language code of the user‘s native language,
+  enabling false friends checks for some language pairs.
+- `languageTool.preferredVariants`: Comma-separated list of preferred language
+  variants. The language detector used with language=auto can detect e.g.
+  English, but it cannot decide whether British English or American English is
+  used. Thus, this parameter can be used to specify the preferred variants like
+  en-GB and de-AT. Only available with language=auto.
+- `lintOnChange`: Lint every time the document changes. Use with caution.
+- `publicApi`: Use the public LanguageTool API Service.
+- `url`: URL of your LanguageTool server. Defaults to localhost on port 8081.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
       },
       {
         "command": "languagetoolLinter.checkDocumentAsPlainText",
-        "title": "Check as Plain Text Document",
+        "title": "Force Check as Plain Text Document",
         "category": "LanguageTool Linter"
       },
       {
@@ -76,7 +76,7 @@
         },
         {
           "command": "languagetoolLinter.checkDocumentAsPlainText",
-          "when": "editorLangId != markdown || editorLangId != html"
+          "when": "editorLangId != markdown && editorLangId != html"
         },
         {
           "command": "languagetoolLinter.clearDocumentDiagnostics"
@@ -95,8 +95,8 @@
         },
         {
           "command": "languagetoolLinter.checkDocumentAsPlainText",
-          "title": "LanguageTool: Check as Plain Text Document",
-          "when": "editorLangId != markdown || editorLangId != html",
+          "title": "LanguageTool: Force Check as Plain Text Document",
+          "when": "editorLangId != markdown && editorLangId != html",
           "group": "LanguageTool"
         },
         {
@@ -448,12 +448,12 @@
           "default": true,
           "description": "Shows a hint for ignored words, providing a Quick Fix to remove the word from the ignored list."
         },
-        "languageToolLinter.plaintext.enabled": {
+        "languageToolLinter.plainText.enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Enable linting of documents as plain text. The entire document is sent to LanguageTool as-is."
+          "description": "Enable linting of documents as plain text. The entire document is sent to LanguageTool as-is. Use Plain Text > Language IDs to determine which documents are considered Plain Text."
         },
-        "languageToolLinter.plaintext.languageIds": {
+        "languageToolLinter.plainText.languageIds": {
           "type": "array",
           "items": {
             "type": "string"

--- a/package.json
+++ b/package.json
@@ -161,17 +161,6 @@
           "default": false,
           "description": "Lint documents when they're opened."
         },
-        "languageToolLinter.plainTextLanguageIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "plaintext",
-            "json"
-          ],
-          "description": "Language IDs to treat as plaintext."
-        },
         "languageToolLinter.serviceType": {
           "type": "string",
           "default": "external",

--- a/package.json
+++ b/package.json
@@ -40,15 +40,26 @@
     "onLanguage:plaintext",
     "onLanguage:markdown",
     "onLanguage:html",
-    "onCommand:languagetoolLinter.lintCurrentDocument",
+    "onCommand:languagetoolLinter.checkDocument",
+    "onCommand:languagetoolLinter.checkDocumentAsPlainText",
     "onCommand:languagetoolLinter.smartFormatDocument"
   ],
   "main": "./dist/extension",
   "contributes": {
     "commands": [
       {
-        "command": "languagetoolLinter.lintCurrentDocument",
-        "title": "Lint Current Document",
+        "command": "languagetoolLinter.checkDocument",
+        "title": "Check Document",
+        "category": "LanguageTool Linter"
+      },
+      {
+        "command": "languagetoolLinter.checkDocumentAsPlainText",
+        "title": "Check as Plain Text Document",
+        "category": "LanguageTool Linter"
+      },
+      {
+        "command": "languagetoolLinter.clearDocumentDiagnostics",
+        "title": "Clear Document Diagnostics",
         "category": "LanguageTool Linter"
       },
       {
@@ -57,6 +68,50 @@
         "category": "LanguageTool Linter"
       }
     ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "languagetoolLinter.checkDocument",
+          "when": "editorLangId == markdown || editorLangId == html"
+        },
+        {
+          "command": "languagetoolLinter.checkDocumentAsPlainText",
+          "when": "editorLangId != markdown || editorLangId != html"
+        },
+        {
+          "command": "languagetoolLinter.clearDocumentDiagnostics"
+        },
+        {
+          "command": "languagetoolLinter.smartFormatDocument",
+          "when": "editorLangId == markdown || editorLangId == html"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "languagetoolLinter.checkDocument",
+          "title": "LanguageTool: Check Document",
+          "when": "editorLangId == markdown || editorLangId == html",
+          "group": "LanguageTool"
+        },
+        {
+          "command": "languagetoolLinter.checkDocumentAsPlainText",
+          "title": "LanguageTool: Check as Plain Text Document",
+          "when": "editorLangId != markdown || editorLangId != html",
+          "group": "LanguageTool"
+        },
+        {
+          "command": "languagetoolLinter.clearDocumentDiagnostics",
+          "title": "LanguageTool: Clear Document Diagnotics",
+          "group": "LanguageTool"
+        },
+        {
+          "command": "languagetoolLinter.smartFormatDocument",
+          "title": "LanguageTool: Smart Format Document",
+          "when": "editorLangId == markdown || editorLangId == html",
+          "group": "LanguageTool"
+        }
+      ]
+    },
     "configuration": {
       "type": "object",
       "title": "LanguageTool Linter",
@@ -105,6 +160,17 @@
           "type": "boolean",
           "default": false,
           "description": "Lint documents when they're opened."
+        },
+        "languageToolLinter.plainTextLanguageIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "plaintext",
+            "json"
+          ],
+          "description": "Language IDs to treat as plaintext."
         },
         "languageToolLinter.serviceType": {
           "type": "string",
@@ -381,6 +447,21 @@
           "type": "boolean",
           "default": true,
           "description": "Shows a hint for ignored words, providing a Quick Fix to remove the word from the ignored list."
+        },
+        "languageToolLinter.plaintext.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable linting of documents as plain text. The entire document is sent to LanguageTool as-is."
+        },
+        "languageToolLinter.plaintext.languageIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "plaintext"
+          ],
+          "markdownDescription": "A list of [Language IDs](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers) to treat as plain text."
         }
       }
     }

--- a/src/configuration/constants.ts
+++ b/src/configuration/constants.ts
@@ -79,6 +79,8 @@ export const CONFIGURATION_DOCUMENT_LANGUAGE_IDS: string[] = [
   LANGUAGE_ID_HTML,
   LANGUAGE_ID_PLAINTEXT,
 ];
+export const CONFIGURATION_PLAIN_TEXT_ENABLED = "plaintext.enabled";
+export const CONFIGURATION_PLAIN_TEXT_IDS = "plaintext.languageIds";
 
 // LanguageTool Services
 export const SERVICE_PUBLIC_URL = "https://languagetool.org/api";

--- a/src/configuration/constants.ts
+++ b/src/configuration/constants.ts
@@ -50,21 +50,21 @@ export const SELECTOR_HTML_UNTITLED: DocumentSelector = {
   language: LANGUAGE_ID_HTML,
   scheme: SCHEME_UNTITLED,
 };
-export const SELECTOR_PLAINTEXT_FILE: DocumentSelector = {
-  language: LANGUAGE_ID_PLAINTEXT,
-  scheme: SCHEME_FILE,
-};
-export const SELECTOR_PLAINTEXT_UNTITLED: DocumentSelector = {
-  language: LANGUAGE_ID_PLAINTEXT,
-  scheme: SCHEME_UNTITLED,
-};
+// export const SELECTOR_PLAINTEXT_FILE: DocumentSelector = {
+//   language: LANGUAGE_ID_PLAINTEXT,
+//   scheme: SCHEME_FILE,
+// };
+// export const SELECTOR_PLAINTEXT_UNTITLED: DocumentSelector = {
+//   language: LANGUAGE_ID_PLAINTEXT,
+//   scheme: SCHEME_UNTITLED,
+// };
 export const DOCUMENT_SELECTORS: DocumentSelector[] = [
   SELECTOR_MARKDOWN_FILE,
   SELECTOR_MARKDOWN_UNTITLED,
   SELECTOR_HTML_FILE,
   SELECTOR_HTML_UNTITLED,
-  SELECTOR_PLAINTEXT_FILE,
-  SELECTOR_PLAINTEXT_UNTITLED,
+  // SELECTOR_PLAINTEXT_FILE,
+  // SELECTOR_PLAINTEXT_UNTITLED,
 ];
 
 // Configuration Strings
@@ -77,10 +77,10 @@ export const CONFIGURATION_IGNORED_WORD_HINT = "languageTool.ignoredWordHint";
 export const CONFIGURATION_DOCUMENT_LANGUAGE_IDS: string[] = [
   LANGUAGE_ID_MARKDOWN,
   LANGUAGE_ID_HTML,
-  LANGUAGE_ID_PLAINTEXT,
+  // LANGUAGE_ID_PLAINTEXT,
 ];
-export const CONFIGURATION_PLAIN_TEXT_ENABLED = "plaintext.enabled";
-export const CONFIGURATION_PLAIN_TEXT_IDS = "plaintext.languageIds";
+export const CONFIGURATION_PLAIN_TEXT_ENABLED = "plainText.enabled";
+export const CONFIGURATION_PLAIN_TEXT_IDS = "plainText.languageIds";
 
 // LanguageTool Services
 export const SERVICE_PUBLIC_URL = "https://languagetool.org/api";

--- a/src/configuration/constants.ts
+++ b/src/configuration/constants.ts
@@ -19,7 +19,7 @@ import { DocumentSelector, OutputChannel, window } from "vscode";
 // General Extension
 export const EXTENSION_TIMEOUT_MS = 500;
 export const EXTENSION_OUTPUT_CHANNEL: OutputChannel = window.createOutputChannel(
-  "LanguageTool Linter"
+  "LanguageTool Linter",
 );
 export const EXTENSION_DISPLAY_NAME = "languagetool-linter";
 export const EXTENSION_DIAGNOSTIC_SOURCE = "LanguageTool";

--- a/src/configuration/constants.ts
+++ b/src/configuration/constants.ts
@@ -27,7 +27,6 @@ export const EXTENSION_DIAGNOSTIC_SOURCE = "LanguageTool";
 // Programming Language IDs
 export const LANGUAGE_ID_MARKDOWN = "markdown";
 export const LANGUAGE_ID_HTML = "html";
-export const LANGUAGE_ID_PLAINTEXT = "plaintext";
 
 // File Scheme
 export const SCHEME_FILE = "file";
@@ -50,21 +49,12 @@ export const SELECTOR_HTML_UNTITLED: DocumentSelector = {
   language: LANGUAGE_ID_HTML,
   scheme: SCHEME_UNTITLED,
 };
-// export const SELECTOR_PLAINTEXT_FILE: DocumentSelector = {
-//   language: LANGUAGE_ID_PLAINTEXT,
-//   scheme: SCHEME_FILE,
-// };
-// export const SELECTOR_PLAINTEXT_UNTITLED: DocumentSelector = {
-//   language: LANGUAGE_ID_PLAINTEXT,
-//   scheme: SCHEME_UNTITLED,
-// };
+
 export const DOCUMENT_SELECTORS: DocumentSelector[] = [
   SELECTOR_MARKDOWN_FILE,
   SELECTOR_MARKDOWN_UNTITLED,
   SELECTOR_HTML_FILE,
   SELECTOR_HTML_UNTITLED,
-  // SELECTOR_PLAINTEXT_FILE,
-  // SELECTOR_PLAINTEXT_UNTITLED,
 ];
 
 // Configuration Strings
@@ -77,7 +67,6 @@ export const CONFIGURATION_IGNORED_WORD_HINT = "languageTool.ignoredWordHint";
 export const CONFIGURATION_DOCUMENT_LANGUAGE_IDS: string[] = [
   LANGUAGE_ID_MARKDOWN,
   LANGUAGE_ID_HTML,
-  // LANGUAGE_ID_PLAINTEXT,
 ];
 export const CONFIGURATION_PLAIN_TEXT_ENABLED = "plainText.enabled";
 export const CONFIGURATION_PLAIN_TEXT_IDS = "plainText.languageIds";

--- a/src/configuration/manager.ts
+++ b/src/configuration/manager.ts
@@ -105,14 +105,36 @@ export class ConfigurationManager implements Disposable {
 
   // Is Language ID Supported?
   public isSupportedDocument(document: TextDocument): boolean {
-    if (document.uri.scheme === "file") {
-      return (
-        Constants.CONFIGURATION_DOCUMENT_LANGUAGE_IDS.indexOf(
+    if (
+      document.uri.scheme === Constants.SCHEME_FILE ||
+      document.uri.scheme === Constants.SCHEME_UNTITLED
+    ) {
+      if (
+        this.isPlainTextId(document.languageId) &&
+        this.isPlainTextEnabled()
+      ) {
+        return true;
+      } else {
+        return Constants.CONFIGURATION_DOCUMENT_LANGUAGE_IDS.includes(
           document.languageId
-        ) > -1
-      );
+        );
+      }
     }
     return false;
+  }
+
+  // Is Plain Text Checking Enabled?
+  public isPlainTextEnabled(): boolean {
+    return this.config.get(
+      Constants.CONFIGURATION_PLAIN_TEXT_ENABLED
+    ) as boolean;
+  }
+
+  // Is the Language ID Considered "Plain Text"?
+  public isPlainTextId(languageId: string): boolean {
+    const languageIds: string[] =
+      this.config.get(Constants.CONFIGURATION_PLAIN_TEXT_IDS) || [];
+    return languageIds.includes(languageId);
   }
 
   public getServiceType(): string {

--- a/src/configuration/manager.ts
+++ b/src/configuration/manager.ts
@@ -77,7 +77,7 @@ export class ConfigurationManager implements Disposable {
     // Only allow preferred variants when language === auto
     if (
       event.affectsConfiguration(
-        "languageToolLinter.languageTool.preferredVariants"
+        "languageToolLinter.languageTool.preferredVariants",
       ) ||
       event.affectsConfiguration("languageToolLinter.languageTool.language")
     ) {
@@ -87,7 +87,7 @@ export class ConfigurationManager implements Disposable {
       ) {
         window.showErrorMessage(
           "Cannot use preferred variants unless language is set to auto. \
-          Please review your configuration settings for LanguageTool."
+          Please review your configuration settings for LanguageTool.",
         );
       }
     }
@@ -116,7 +116,7 @@ export class ConfigurationManager implements Disposable {
         return true;
       } else {
         return Constants.CONFIGURATION_DOCUMENT_LANGUAGE_IDS.includes(
-          document.languageId
+          document.languageId,
         );
       }
     }
@@ -126,7 +126,7 @@ export class ConfigurationManager implements Disposable {
   // Is Plain Text Checking Enabled?
   public isPlainTextEnabled(): boolean {
     return this.config.get(
-      Constants.CONFIGURATION_PLAIN_TEXT_ENABLED
+      Constants.CONFIGURATION_PLAIN_TEXT_ENABLED,
     ) as boolean;
   }
 
@@ -184,7 +184,7 @@ export class ConfigurationManager implements Disposable {
       return DiagnosticSeverity.Warning;
     } else {
       window.showWarningMessage(
-        '"LanguageTool Linter > Diagnostic Severity" is unknown. Defaulting to "Warning".'
+        '"LanguageTool Linter > Diagnostic Severity" is unknown. Defaulting to "Warning".',
       );
       return DiagnosticSeverity.Warning;
     }
@@ -198,7 +198,7 @@ export class ConfigurationManager implements Disposable {
     if (jarFile !== "") {
       window.showWarningMessage(
         '"LanguageTool Linter > Managed: Jar File" is deprecated. \
-        Please use "LanguageTool > Managed: Class Path" instead.'
+        Please use "LanguageTool > Managed: Class Path" instead.',
       );
       classPathFiles.push(jarFile);
     }
@@ -217,7 +217,7 @@ export class ConfigurationManager implements Disposable {
   public stopManagedService(): void {
     if (this.process) {
       Constants.EXTENSION_OUTPUT_CHANNEL.appendLine(
-        "Closing managed service server."
+        "Closing managed service server.",
       );
       this.process.cancel();
       this.process = undefined;
@@ -286,7 +286,7 @@ export class ConfigurationManager implements Disposable {
   // Show hints for ignored words?
   public showIgnoredWordHints(): boolean {
     return this.config.get(
-      Constants.CONFIGURATION_IGNORED_WORD_HINT
+      Constants.CONFIGURATION_IGNORED_WORD_HINT,
     ) as boolean;
   }
 
@@ -347,7 +347,7 @@ export class ConfigurationManager implements Disposable {
       if (minimumPort > maximumPort) {
         window.showWarningMessage(
           "LanguageTool Linter - The minimum port is greater than the maximum port. \
-          Cancelling start of managed service. Please adjust your settings and try again."
+          Cancelling start of managed service. Please adjust your settings and try again.",
         );
       } else {
         portfinder.getPort(
@@ -355,7 +355,7 @@ export class ConfigurationManager implements Disposable {
           (error: any, port: number) => {
             if (error) {
               Constants.EXTENSION_OUTPUT_CHANNEL.appendLine(
-                "Error getting open port: " + error.message
+                "Error getting open port: " + error.message,
               );
               Constants.EXTENSION_OUTPUT_CHANNEL.show(true);
             } else {
@@ -368,19 +368,19 @@ export class ConfigurationManager implements Disposable {
                 port.toString(),
               ];
               Constants.EXTENSION_OUTPUT_CHANNEL.appendLine(
-                "Starting managed service."
+                "Starting managed service.",
               );
               (this.process = execa("java", args)).catch((err: any) => {
                 if (err.isCanceled) {
                   Constants.EXTENSION_OUTPUT_CHANNEL.appendLine(
-                    "Managed service process stopped."
+                    "Managed service process stopped.",
                   );
                 } else if (err.failed) {
                   Constants.EXTENSION_OUTPUT_CHANNEL.appendLine(
-                    "Managed service command failed: " + err.command
+                    "Managed service command failed: " + err.command,
                   );
                   Constants.EXTENSION_OUTPUT_CHANNEL.appendLine(
-                    "Error Message: " + err.message
+                    "Error Message: " + err.message,
                   );
                   Constants.EXTENSION_OUTPUT_CHANNEL.show(true);
                 }
@@ -394,7 +394,7 @@ export class ConfigurationManager implements Disposable {
               });
               this.serviceUrl = this.findServiceUrl(this.getServiceType());
             }
-          }
+          },
         );
       }
     }
@@ -404,7 +404,7 @@ export class ConfigurationManager implements Disposable {
   private saveIgnoredWords(
     words: Set<string>,
     section: string,
-    configurationTarget: ConfigurationTarget
+    configurationTarget: ConfigurationTarget,
   ): void {
     const wordArray: string[] = Array.from(words)
       .map((word) => word.toLowerCase())
@@ -417,7 +417,7 @@ export class ConfigurationManager implements Disposable {
     this.saveIgnoredWords(
       globallyIgnoredWords,
       Constants.CONFIGURATION_GLOBAL_IGNORED_WORDS,
-      ConfigurationTarget.Global
+      ConfigurationTarget.Global,
     );
   }
   // Save word to Workspace Level ignored word list.
@@ -425,7 +425,7 @@ export class ConfigurationManager implements Disposable {
     this.saveIgnoredWords(
       workspaceIgnoredWords,
       Constants.CONFIGURATION_WORKSPACE_IGNORED_WORDS,
-      ConfigurationTarget.Workspace
+      ConfigurationTarget.Workspace,
     );
   }
 
@@ -443,7 +443,7 @@ export class ConfigurationManager implements Disposable {
   // Get Workspace ignored words from settings.
   private getWorkspaceIgnoredWords(): Set<string> {
     return this.getIgnoredWords(
-      Constants.CONFIGURATION_WORKSPACE_IGNORED_WORDS
+      Constants.CONFIGURATION_WORKSPACE_IGNORED_WORDS,
     );
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(Constants.EXTENSION_OUTPUT_CHANNEL);
   Constants.EXTENSION_OUTPUT_CHANNEL.appendLine(
-    "LanguageTool Linter Activated!"
+    "LanguageTool Linter Activated!",
   );
 
   // Register onDidChangeconfiguration event
@@ -49,7 +49,7 @@ export function activate(context: vscode.ExtensionContext): void {
       if (event.affectsConfiguration("languageToolLinter")) {
         configMan.reloadConfiguration(event);
       }
-    })
+    }),
   );
 
   // Register onDidOpenTextDocument event - request lint
@@ -58,7 +58,7 @@ export function activate(context: vscode.ExtensionContext): void {
       if (configMan.isLintOnOpen()) {
         linter.requestLint(document);
       }
-    })
+    }),
   );
 
   // Register onDidChangeTextDocument event - request lint with default timeout
@@ -70,7 +70,7 @@ export function activate(context: vscode.ExtensionContext): void {
         }
         linter.requestLint(event.document);
       }
-    })
+    }),
   );
 
   // Register onDidChangeActiveTextEditor event - request lint
@@ -79,7 +79,7 @@ export function activate(context: vscode.ExtensionContext): void {
       if (editor !== undefined && configMan.isLintOnChange()) {
         linter.requestLint(editor.document);
       }
-    })
+    }),
   );
 
   // Register onWillSaveTextDocument event - smart format if enabled
@@ -87,10 +87,10 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.workspace.onWillSaveTextDocument((event) => {
       if (configMan.isSmartFormatOnSave()) {
         vscode.commands.executeCommand(
-          "languagetoolLinter.smartFormatDocument"
+          "languagetoolLinter.smartFormatDocument",
         );
       }
-    })
+    }),
   );
 
   // Register onDidSaveTextDocument event - request immediate lint
@@ -99,7 +99,7 @@ export function activate(context: vscode.ExtensionContext): void {
       if (configMan.isLintOnSave()) {
         linter.requestLint(document);
       }
-    })
+    }),
   );
 
   // Register onDidCloseTextDocument event - cancel any pending lint
@@ -107,13 +107,13 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.workspace.onDidCloseTextDocument((document: vscode.TextDocument) => {
       linter.cancelLint(document);
       linter.clearDiagnostics(document.uri);
-    })
+    }),
   );
 
   // Register Code Actions Provider for supported languages
   Constants.DOCUMENT_SELECTORS.forEach((selector: vscode.DocumentSelector) => {
     context.subscriptions.push(
-      vscode.languages.registerCodeActionsProvider(selector, linter)
+      vscode.languages.registerCodeActionsProvider(selector, linter),
     );
 
     if (onTypeTriggers) {
@@ -122,8 +122,8 @@ export function activate(context: vscode.ExtensionContext): void {
           selector,
           onTypeDispatcher,
           onTypeTriggers.first,
-          ...onTypeTriggers.more
-        )
+          ...onTypeTriggers.more,
+        ),
       );
     }
   });
@@ -132,7 +132,7 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.workspace.onDidCloseTextDocument((document: vscode.TextDocument) => {
       linter.clearDiagnostics(document.uri);
-    })
+    }),
   );
 
   // Register "Ignore Word Globally" TextEditorCommand
@@ -141,7 +141,7 @@ export function activate(context: vscode.ExtensionContext): void {
     (editor, edit, ...args) => {
       configMan.ignoreWordGlobally(args.shift());
       linter.requestLint(editor.document, 0);
-    }
+    },
   );
   context.subscriptions.push(ignoreWordGlobally);
 
@@ -151,7 +151,7 @@ export function activate(context: vscode.ExtensionContext): void {
     (editor, edit, ...args) => {
       configMan.ignoreWordInWorkspace(args.shift());
       linter.requestLint(editor.document, 0);
-    }
+    },
   );
   context.subscriptions.push(ignoreWordInWorkspace);
 
@@ -161,7 +161,7 @@ export function activate(context: vscode.ExtensionContext): void {
     (editor, edit, ...args) => {
       configMan.removeGloballyIgnoredWord(args.shift());
       linter.requestLint(editor.document, 0);
-    }
+    },
   );
   context.subscriptions.push(removeGloballyIgnoredWord);
 
@@ -171,7 +171,7 @@ export function activate(context: vscode.ExtensionContext): void {
     (editor, edit, ...args) => {
       configMan.removeWorkspaceIgnoredWord(args.shift());
       linter.requestLint(editor.document, 0);
-    }
+    },
   );
   context.subscriptions.push(removeWorkspaceIgnoredWord);
 
@@ -180,7 +180,7 @@ export function activate(context: vscode.ExtensionContext): void {
     "languagetoolLinter.checkDocument",
     (editor: vscode.TextEditor, edit: vscode.TextEditorEdit) => {
       linter.requestLint(editor.document, 0);
-    }
+    },
   );
   context.subscriptions.push(checkDocument);
 
@@ -189,7 +189,7 @@ export function activate(context: vscode.ExtensionContext): void {
     "languagetoolLinter.checkDocumentAsPlainText",
     (editor: vscode.TextEditor, edit: vscode.TextEditorEdit) => {
       linter.requestLintAsPlainText(editor.document, 0);
-    }
+    },
   );
   context.subscriptions.push(checkDocumentAsPlainText);
 
@@ -198,7 +198,7 @@ export function activate(context: vscode.ExtensionContext): void {
     "languagetoolLinter.clearDocumentDiagnostics",
     (editor: vscode.TextEditor, edit: vscode.TextEditorEdit) => {
       linter.clearDiagnostics(editor.document.uri);
-    }
+    },
   );
   context.subscriptions.push(clearDocumentDiagnostics);
 
@@ -211,19 +211,19 @@ export function activate(context: vscode.ExtensionContext): void {
         const text: string = editor.document.getText();
         const lastOffset: number = text.length;
         const annotatedtext: IAnnotatedtext = linter.buildAnnotatedtext(
-          editor.document
+          editor.document,
         );
         const newText = linter.smartFormatAnnotatedtext(annotatedtext);
         // Replace the whole thing at once so undo applies to all changes.
         edit.replace(
           new vscode.Range(
             editor.document.positionAt(0),
-            editor.document.positionAt(lastOffset)
+            editor.document.positionAt(lastOffset),
           ),
-          newText
+          newText,
         );
       }
-    }
+    },
   );
   context.subscriptions.push(smartFormatCommand);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,14 +175,32 @@ export function activate(context: vscode.ExtensionContext): void {
   );
   context.subscriptions.push(removeWorkspaceIgnoredWord);
 
-  // Register "Lint Current Document" TextEditorCommand
-  const lintCommand = vscode.commands.registerTextEditorCommand(
-    "languagetoolLinter.lintCurrentDocument",
+  // Register "Check Current Document" TextEditorCommand
+  const checkDocument = vscode.commands.registerTextEditorCommand(
+    "languagetoolLinter.checkDocument",
     (editor: vscode.TextEditor, edit: vscode.TextEditorEdit) => {
       linter.requestLint(editor.document, 0);
     }
   );
-  context.subscriptions.push(lintCommand);
+  context.subscriptions.push(checkDocument);
+
+  // Register "Check as Plain Text Document" TextEditorCommand
+  const checkDocumentAsPlainText = vscode.commands.registerTextEditorCommand(
+    "languagetoolLinter.checkDocumentAsPlainText",
+    (editor: vscode.TextEditor, edit: vscode.TextEditorEdit) => {
+      linter.requestLintAsPlainText(editor.document, 0);
+    }
+  );
+  context.subscriptions.push(checkDocumentAsPlainText);
+
+  // Register "Clear LanguageTool Diagnostics" TextEditorCommand
+  const clearDocumentDiagnostics = vscode.commands.registerTextEditorCommand(
+    "languagetoolLinter.clearDocumentDiagnostics",
+    (editor: vscode.TextEditor, edit: vscode.TextEditorEdit) => {
+      linter.clearDiagnostics(editor.document.uri);
+    }
+  );
+  context.subscriptions.push(clearDocumentDiagnostics);
 
   // Register "Smart Format Document" TextEditorCommand
   const smartFormatCommand = vscode.commands.registerTextEditorCommand(

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -194,12 +194,12 @@ export class Linter implements CodeActionProvider {
   // Perform Lint on Document
   public lintDocument(document: TextDocument): void {
     if (this.configManager.isSupportedDocument(document)) {
-      if (document.languageId === "markdown") {
+      if (document.languageId === Constants.LANGUAGE_ID_MARKDOWN) {
         const annotatedMarkdown: string = JSON.stringify(
           this.buildAnnotatedMarkdown(document.getText())
         );
         this.lintAnnotatedText(document, annotatedMarkdown);
-      } else if (document.languageId === "html") {
+      } else if (document.languageId === Constants.LANGUAGE_ID_HTML) {
         const annotatedHTML: string = JSON.stringify(
           this.buildAnnotatedHTML(document.getText())
         );
@@ -223,11 +223,9 @@ export class Linter implements CodeActionProvider {
     document: TextDocument,
     annotatedText: string
   ): void {
-    if (this.configManager.isSupportedDocument(document)) {
-      const ltPostDataDict: any = this.getPostDataTemplate();
-      ltPostDataDict.data = annotatedText;
-      this.callLanguageTool(document, ltPostDataDict);
-    }
+    const ltPostDataDict: any = this.getPostDataTemplate();
+    ltPostDataDict.data = annotatedText;
+    this.callLanguageTool(document, ltPostDataDict);
   }
 
   // Apply smart formatting to annotated text.

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -127,10 +127,21 @@ export class Linter implements CodeActionProvider {
       const uriString = document.uri.toString();
       const timeout = setTimeout(() => {
         this.lintDocument(document);
-        this.cancelLint(document);
       }, timeoutDuration);
       this.timeoutMap.set(uriString, timeout);
     }
+  }
+  // Force request a lint for a document as plain text regardless of language id
+  public requestLintAsPlainText(
+    document: TextDocument,
+    timeoutDuration: number = Constants.EXTENSION_TIMEOUT_MS
+  ): void {
+    this.cancelLint(document);
+    const uriString = document.uri.toString();
+    const timeout = setTimeout(() => {
+      this.lintDocumentAsPlainText(document);
+    }, timeoutDuration);
+    this.timeoutMap.set(uriString, timeout);
   }
 
   // Cancel lint
@@ -194,12 +205,17 @@ export class Linter implements CodeActionProvider {
         );
         this.lintAnnotatedText(document, annotatedHTML);
       } else {
-        const annotatedPlaintext: string = JSON.stringify(
-          this.buildAnnotatedPlaintext(document.getText())
-        );
-        this.lintAnnotatedText(document, annotatedPlaintext);
+        this.lintDocumentAsPlainText(document);
       }
     }
+  }
+
+  // Perform Lint on Document As Plain Text
+  public lintDocumentAsPlainText(document: TextDocument): void {
+    const annotatedPlaintext: string = JSON.stringify(
+      this.buildAnnotatedPlaintext(document.getText())
+    );
+    this.lintAnnotatedText(document, annotatedPlaintext);
   }
 
   // Lint Annotated Text

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -71,7 +71,7 @@ export class Linter implements CodeActionProvider {
     this.configManager = configManager;
     this.timeoutMap = new Map<string, NodeJS.Timeout>();
     this.diagnosticCollection = languages.createDiagnosticCollection(
-      Constants.EXTENSION_DISPLAY_NAME
+      Constants.EXTENSION_DISPLAY_NAME,
     );
     this.remarkBuilderOptions.interpretmarkup = this.customMarkdownInterpreter;
   }
@@ -81,14 +81,14 @@ export class Linter implements CodeActionProvider {
     document: TextDocument,
     range: Range,
     context: CodeActionContext,
-    token: CancellationToken
+    token: CancellationToken,
   ): CodeAction[] {
     const diagnostics = context.diagnostics || [];
     const actions: CodeAction[] = [];
     diagnostics
       .filter(
         (diagnostic) =>
-          diagnostic.source === Constants.EXTENSION_DIAGNOSTIC_SOURCE
+          diagnostic.source === Constants.EXTENSION_DIAGNOSTIC_SOURCE,
       )
       .forEach((diagnostic) => {
         // @ts-ignore
@@ -96,7 +96,7 @@ export class Linter implements CodeActionProvider {
         if (Linter.isSpellingRule(match.rule.id)) {
           const spellingActions: CodeAction[] = this.getSpellingRuleActions(
             document,
-            diagnostic
+            diagnostic,
           );
           if (spellingActions.length > 0) {
             spellingActions.forEach((action) => {
@@ -120,7 +120,7 @@ export class Linter implements CodeActionProvider {
   // Request a lint for a document
   public requestLint(
     document: TextDocument,
-    timeoutDuration: number = Constants.EXTENSION_TIMEOUT_MS
+    timeoutDuration: number = Constants.EXTENSION_TIMEOUT_MS,
   ): void {
     if (this.configManager.isSupportedDocument(document)) {
       this.cancelLint(document);
@@ -134,7 +134,7 @@ export class Linter implements CodeActionProvider {
   // Force request a lint for a document as plain text regardless of language id
   public requestLintAsPlainText(
     document: TextDocument,
-    timeoutDuration: number = Constants.EXTENSION_TIMEOUT_MS
+    timeoutDuration: number = Constants.EXTENSION_TIMEOUT_MS,
   ): void {
     this.cancelLint(document);
     const uriString = document.uri.toString();
@@ -150,7 +150,7 @@ export class Linter implements CodeActionProvider {
     if (this.timeoutMap.has(uriString)) {
       if (this.timeoutMap.has(uriString)) {
         const timeout: NodeJS.Timeout = this.timeoutMap.get(
-          uriString
+          uriString,
         ) as NodeJS.Timeout;
         clearTimeout(timeout);
         this.timeoutMap.delete(uriString);
@@ -196,12 +196,12 @@ export class Linter implements CodeActionProvider {
     if (this.configManager.isSupportedDocument(document)) {
       if (document.languageId === Constants.LANGUAGE_ID_MARKDOWN) {
         const annotatedMarkdown: string = JSON.stringify(
-          this.buildAnnotatedMarkdown(document.getText())
+          this.buildAnnotatedMarkdown(document.getText()),
         );
         this.lintAnnotatedText(document, annotatedMarkdown);
       } else if (document.languageId === Constants.LANGUAGE_ID_HTML) {
         const annotatedHTML: string = JSON.stringify(
-          this.buildAnnotatedHTML(document.getText())
+          this.buildAnnotatedHTML(document.getText()),
         );
         this.lintAnnotatedText(document, annotatedHTML);
       } else {
@@ -213,7 +213,7 @@ export class Linter implements CodeActionProvider {
   // Perform Lint on Document As Plain Text
   public lintDocumentAsPlainText(document: TextDocument): void {
     const annotatedPlaintext: string = JSON.stringify(
-      this.buildAnnotatedPlaintext(document.getText())
+      this.buildAnnotatedPlaintext(document.getText()),
     );
     this.lintAnnotatedText(document, annotatedPlaintext);
   }
@@ -221,7 +221,7 @@ export class Linter implements CodeActionProvider {
   // Lint Annotated Text
   public lintAnnotatedText(
     document: TextDocument,
-    annotatedText: string
+    annotatedText: string,
   ): void {
     const ltPostDataDict: any = this.getPostDataTemplate();
     ltPostDataDict.data = annotatedText;
@@ -239,11 +239,11 @@ export class Linter implements CodeActionProvider {
           .replace(/'(?=[\w"“])/g, QuotesFormattingProvider.startSingleQuote)
           .replace(
             /([\w.!?%,'’])"/g,
-            "$1" + QuotesFormattingProvider.endDoubleQuote
+            "$1" + QuotesFormattingProvider.endDoubleQuote,
           )
           .replace(
             /([\w.!?%,"”])'/g,
-            "$1" + QuotesFormattingProvider.endSingleQuote
+            "$1" + QuotesFormattingProvider.endSingleQuote,
           )
           .replace(/([\w])---(?=[\w])/g, "$1" + DashesFormattingProvider.emDash)
           .replace(/([\w])--(?=[\w])/g, "$1" + DashesFormattingProvider.enDash)
@@ -301,13 +301,13 @@ export class Linter implements CodeActionProvider {
         })
         .catch((err) => {
           Constants.EXTENSION_OUTPUT_CHANNEL.appendLine(
-            "Error connecting to " + url
+            "Error connecting to " + url,
           );
           Constants.EXTENSION_OUTPUT_CHANNEL.appendLine(err);
         });
     } else {
       Constants.EXTENSION_OUTPUT_CHANNEL.appendLine(
-        "No LanguageTool URL provided. Please check your settings and try again."
+        "No LanguageTool URL provided. Please check your settings and try again.",
       );
       Constants.EXTENSION_OUTPUT_CHANNEL.show(true);
     }
@@ -316,7 +316,7 @@ export class Linter implements CodeActionProvider {
   // Convert LanguageTool Suggestions into QuickFix CodeActions
   private suggest(
     document: TextDocument,
-    response: ILanguageToolResponse
+    response: ILanguageToolResponse,
   ): void {
     const matches = response.matches;
     const diagnostics: Diagnostic[] = [];
@@ -330,7 +330,7 @@ export class Linter implements CodeActionProvider {
       const diagnostic: Diagnostic = new Diagnostic(
         diagnosticRange,
         diagnosticMessage,
-        diagnosticSeverity
+        diagnosticSeverity,
       );
       diagnostic.source = Constants.EXTENSION_DIAGNOSTIC_SOURCE;
       // @ts-ignore
@@ -365,7 +365,7 @@ export class Linter implements CodeActionProvider {
   // Get CodeActions for Spelling Rules
   private getSpellingRuleActions(
     document: TextDocument,
-    diagnostic: Diagnostic
+    diagnostic: Diagnostic,
   ): CodeAction[] {
     const actions: CodeAction[] = [];
     // @ts-ignore
@@ -378,7 +378,7 @@ export class Linter implements CodeActionProvider {
             "Remove '" + word + "' from always ignored words.";
           const action: CodeAction = new CodeAction(
             actionTitle,
-            CodeActionKind.QuickFix
+            CodeActionKind.QuickFix,
           );
           action.command = {
             arguments: [word],
@@ -394,7 +394,7 @@ export class Linter implements CodeActionProvider {
             "Remove '" + word + "' from Workspace ignored words.";
           const action: CodeAction = new CodeAction(
             actionTitle,
-            CodeActionKind.QuickFix
+            CodeActionKind.QuickFix,
           );
           action.command = {
             arguments: [word],
@@ -410,7 +410,7 @@ export class Linter implements CodeActionProvider {
       const usrIgnoreActionTitle: string = "Always ignore '" + word + "'";
       const usrIgnoreAction: CodeAction = new CodeAction(
         usrIgnoreActionTitle,
-        CodeActionKind.QuickFix
+        CodeActionKind.QuickFix,
       );
       usrIgnoreAction.command = {
         arguments: [word],
@@ -425,7 +425,7 @@ export class Linter implements CodeActionProvider {
           "Ignore '" + word + "' in Workspace";
         const wsIgnoreAction: CodeAction = new CodeAction(
           wsIgnoreActionTitle,
-          CodeActionKind.QuickFix
+          CodeActionKind.QuickFix,
         );
         wsIgnoreAction.command = {
           arguments: [word],
@@ -439,7 +439,7 @@ export class Linter implements CodeActionProvider {
       this.getReplacementActions(
         document,
         diagnostic,
-        match.replacements
+        match.replacements,
       ).forEach((action: CodeAction) => {
         actions.push(action);
       });
@@ -450,7 +450,7 @@ export class Linter implements CodeActionProvider {
   // Get all Rule CodeActions
   private getRuleActions(
     document: TextDocument,
-    diagnostic: Diagnostic
+    diagnostic: Diagnostic,
   ): CodeAction[] {
     // @ts-ignore
     const match: ILanguageToolMatch = diagnostic.match;
@@ -458,7 +458,7 @@ export class Linter implements CodeActionProvider {
     this.getReplacementActions(
       document,
       diagnostic,
-      match.replacements
+      match.replacements,
     ).forEach((action: CodeAction) => {
       actions.push(action);
     });
@@ -469,14 +469,14 @@ export class Linter implements CodeActionProvider {
   private getReplacementActions(
     document: TextDocument,
     diagnostic: Diagnostic,
-    replacements: ILanguageToolReplacement[]
+    replacements: ILanguageToolReplacement[],
   ): CodeAction[] {
     const actions: CodeAction[] = [];
     replacements.forEach((replacement: ILanguageToolReplacement) => {
       const actionTitle: string = "'" + replacement.value + "'";
       const action: CodeAction = new CodeAction(
         actionTitle,
-        CodeActionKind.QuickFix
+        CodeActionKind.QuickFix,
       );
       const edit: WorkspaceEdit = new WorkspaceEdit();
       edit.replace(document.uri, diagnostic.range, replacement.value);

--- a/src/test-fixtures/workspace/.vscode/settings.json
+++ b/src/test-fixtures/workspace/.vscode/settings.json
@@ -9,6 +9,5 @@
     "languageToolLinter.languageTool.disabledRules": "DASH_RULE",
     "languageToolLinter.lintOnOpen": true,
     "languageToolLinter.lintOnChange": true,
-    "languageToolLinter.managed.classPath": "/usr/local/opt/languagetool/libexec/languagetool-server.jar",
-    "languageToolLinter.serviceType": "managed"
+    "languageToolLinter.managed.classPath": "/usr/local/opt/languagetool/libexec/languagetool-server.jar"
 }

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -14,7 +14,7 @@ async function main() {
 
     const testWorkspace = path.resolve(
       __dirname,
-      "../../test/test-fixtures/workspace"
+      "../../test/test-fixtures/workspace",
     );
 
     // Download VS Code, unzip it and run the integration test

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -12,9 +12,11 @@ suite("Extension Test Suite", () => {
     assert.ok(vscode.extensions.getExtension("davidlday.languagetool-linter"));
   });
 
-  test("Extension should activate", function() {
+  test("Extension should activate", function () {
     this.timeout(60000);
-    const ext: vscode.Extension<any> | undefined = vscode.extensions.getExtension(
+    const ext:
+      | vscode.Extension<any>
+      | undefined = vscode.extensions.getExtension(
       "davidlday.languagetool-linter"
     );
     if (ext) {
@@ -29,7 +31,9 @@ suite("Extension Test Suite", () => {
   test("Extension should register all commands", () => {
     return vscode.commands.getCommands(true).then((commands) => {
       const EXPECTED_COMMANDS: string[] = [
-        "languagetoolLinter.lintCurrentDocument",
+        "languagetoolLinter.checkDocument",
+        "languagetoolLinter.checkDocumentAsPlainText",
+        "languagetoolLinter.clearDocumentDiagnostics",
         "languagetoolLinter.smartFormatDocument",
         "languagetoolLinter.ignoreWordGlobally",
         "languagetoolLinter.ignoreWordInWorkspace",

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -17,7 +17,7 @@ suite("Extension Test Suite", () => {
     const ext:
       | vscode.Extension<any>
       | undefined = vscode.extensions.getExtension(
-      "davidlday.languagetool-linter"
+      "davidlday.languagetool-linter",
     );
     if (ext) {
       ext.activate().then((api: any) => {
@@ -49,7 +49,7 @@ suite("Extension Test Suite", () => {
       assert.equal(
         FOUND_COMMANDS.length,
         EXPECTED_COMMANDS.length,
-        "Either not all commands are registered or new commands have not been added to this test."
+        "Either not all commands are registered or new commands have not been added to this test.",
       );
     });
   });

--- a/src/test/suite/linter.html.test.ts
+++ b/src/test/suite/linter.html.test.ts
@@ -10,7 +10,7 @@ suite("Linter HTML Test Suite", () => {
   const linter: Linter = new Linter(config);
   const testWorkspace: string = path.resolve(
     __dirname,
-    "../../../src/test-fixtures/workspace"
+    "../../../src/test-fixtures/workspace",
   );
 
   test("Linter should instantiate", () => {
@@ -21,12 +21,12 @@ suite("Linter HTML Test Suite", () => {
     const expected: JSON = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, testWorkspace + "/html/basic.json"),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text: string = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/html/basic.html"),
-      "utf8"
+      "utf8",
     );
     const actual: IAnnotatedtext = linter.buildAnnotatedHTML(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), JSON.stringify(actual), "utf8");
@@ -37,12 +37,12 @@ suite("Linter HTML Test Suite", () => {
     const expected: JSON = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, testWorkspace + "/html/escape-character.json"),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text: string = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/html/escape-character.html"),
-      "utf8"
+      "utf8",
     );
     const actual: IAnnotatedtext = linter.buildAnnotatedHTML(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), JSON.stringify(actual), "utf8");

--- a/src/test/suite/linter.markdown.test.ts
+++ b/src/test/suite/linter.markdown.test.ts
@@ -9,7 +9,7 @@ suite("Linter Markdown Test Suite", () => {
   const linter: Linter = new Linter(config);
   const testWorkspace: string = path.resolve(
     __dirname,
-    "../../../src/test-fixtures/workspace"
+    "../../../src/test-fixtures/workspace",
   );
 
   test("Linter should instantiate", () => {
@@ -20,12 +20,12 @@ suite("Linter Markdown Test Suite", () => {
     const expected = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, testWorkspace + "/markdown/backticks.json"),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/markdown/backticks.md"),
-      "utf8"
+      "utf8",
     );
     const actual = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/backticks.json"), JSON.stringify(actual), "utf8");
@@ -37,14 +37,14 @@ suite("Linter Markdown Test Suite", () => {
       fs.readFileSync(
         path.resolve(
           __dirname,
-          testWorkspace + "/markdown/bold-or-italics.json"
+          testWorkspace + "/markdown/bold-or-italics.json",
         ),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/markdown/bold-or-italics.md"),
-      "utf8"
+      "utf8",
     );
     const actual = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/bold-or-italics.json"), JSON.stringify(actual), "utf8");
@@ -55,12 +55,12 @@ suite("Linter Markdown Test Suite", () => {
     const expected = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, testWorkspace + "/markdown/comments.json"),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/markdown/comments.md"),
-      "utf8"
+      "utf8",
     );
     const actual = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/comments.json"), JSON.stringify(actual), "utf8");
@@ -71,12 +71,12 @@ suite("Linter Markdown Test Suite", () => {
     const expected = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, testWorkspace + "/markdown/front-matter.json"),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/markdown/front-matter.md"),
-      "utf8"
+      "utf8",
     );
     const actual = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/front-matter.json"), JSON.stringify(actual), "utf8");
@@ -87,12 +87,12 @@ suite("Linter Markdown Test Suite", () => {
     const expected = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, testWorkspace + "/markdown/headers.json"),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/markdown/headers.md"),
-      "utf8"
+      "utf8",
     );
     const actual = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/headers.json"), JSON.stringify(actual), "utf8");
@@ -103,12 +103,12 @@ suite("Linter Markdown Test Suite", () => {
     const expected = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, testWorkspace + "/markdown/ordered-lists.json"),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/markdown/ordered-lists.md"),
-      "utf8"
+      "utf8",
     );
     const actual = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/ordered-lists.json"), JSON.stringify(actual), "utf8");
@@ -120,14 +120,14 @@ suite("Linter Markdown Test Suite", () => {
       fs.readFileSync(
         path.resolve(
           __dirname,
-          testWorkspace + "/markdown/unordered-lists.json"
+          testWorkspace + "/markdown/unordered-lists.json",
         ),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.md"),
-      "utf8"
+      "utf8",
     );
     const actual = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.json"), JSON.stringify(actual), "utf8");
@@ -139,14 +139,14 @@ suite("Linter Markdown Test Suite", () => {
       fs.readFileSync(
         path.resolve(
           __dirname,
-          testWorkspace + "/markdown/escape-character.json"
+          testWorkspace + "/markdown/escape-character.json",
         ),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/markdown/escape-character.md"),
-      "utf8"
+      "utf8",
     );
     const actual = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/unordered-lists.json"), JSON.stringify(actual), "utf8");

--- a/src/test/suite/linter.test.ts
+++ b/src/test/suite/linter.test.ts
@@ -10,7 +10,7 @@ suite("Linter Test Suite", () => {
   const linter: Linter = new Linter(config);
   const testWorkspace: string = path.resolve(
     __dirname,
-    "../../../src/test-fixtures/workspace"
+    "../../../src/test-fixtures/workspace",
   );
 
   test("Linter should instantiate", () => {
@@ -21,12 +21,12 @@ suite("Linter Test Suite", () => {
     const expected: JSON = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, testWorkspace + "/markdown/basic.json"),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text: string = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/markdown/basic.md"),
-      "utf8"
+      "utf8",
     );
     const actual: IAnnotatedtext = linter.buildAnnotatedMarkdown(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/markdown/basic.json"), JSON.stringify(actual), "utf8");
@@ -37,12 +37,12 @@ suite("Linter Test Suite", () => {
     const expected: JSON = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, testWorkspace + "/html/basic.json"),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text: string = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/html/basic.html"),
-      "utf8"
+      "utf8",
     );
     const actual: IAnnotatedtext = linter.buildAnnotatedHTML(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/html/basic.json"), JSON.stringify(actual), "utf8");
@@ -53,12 +53,12 @@ suite("Linter Test Suite", () => {
     const expected: JSON = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, testWorkspace + "/plaintext/basic.json"),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text: string = fs.readFileSync(
       path.resolve(__dirname, testWorkspace + "/plaintext/basic.txt"),
-      "utf8"
+      "utf8",
     );
     const actual: IAnnotatedtext = linter.buildAnnotatedPlaintext(text);
     // fs.writeFileSync(path.resolve(__dirname, testWorkspace + "/plaintext/basic.json"), JSON.stringify(actual), "utf8");
@@ -69,25 +69,25 @@ suite("Linter Test Suite", () => {
     const expected: string = fs.readFileSync(
       path.resolve(
         __dirname,
-        testWorkspace + "/markdown/smart-format-formatted.md"
+        testWorkspace + "/markdown/smart-format-formatted.md",
       ),
-      "utf8"
+      "utf8",
     );
     const expectedJSON: JSON = JSON.parse(
       fs.readFileSync(
         path.resolve(
           __dirname,
-          testWorkspace + "/markdown/smart-format-unformatted.json"
+          testWorkspace + "/markdown/smart-format-unformatted.json",
         ),
-        "utf8"
-      )
+        "utf8",
+      ),
     );
     const text: string = fs.readFileSync(
       path.resolve(
         __dirname,
-        testWorkspace + "/markdown/smart-format-unformatted.md"
+        testWorkspace + "/markdown/smart-format-unformatted.md",
       ),
-      "utf8"
+      "utf8",
     );
     const annotatedtext: IAnnotatedtext = linter.buildAnnotatedMarkdown(text);
     assert.deepStrictEqual(annotatedtext, expectedJSON);

--- a/src/typeFormatters/dashesFormatter.ts
+++ b/src/typeFormatters/dashesFormatter.ts
@@ -35,14 +35,14 @@ export class DashesFormattingProvider
     position: vscode.Position,
     ch: string,
     options: vscode.FormattingOptions,
-    cancellationToken: vscode.CancellationToken
+    cancellationToken: vscode.CancellationToken,
   ): vscode.TextEdit[] {
     const line: vscode.TextLine = document.lineAt(position.line);
     const range: vscode.Range = new vscode.Range(
       position.line,
       position.character - 2,
       position.line,
-      position.character
+      position.character,
     );
     const prevCh: string =
       position.character > 0 ? line.text.charAt(position.character - 2) : " ";
@@ -58,7 +58,7 @@ export class DashesFormattingProvider
             position.line,
             position.character - 3,
             position.line,
-            position.character
+            position.character,
           );
           return [
             new vscode.TextEdit(expandedRange, DashesFormattingProvider.emDash),

--- a/src/typeFormatters/dispatcher.ts
+++ b/src/typeFormatters/dispatcher.ts
@@ -28,7 +28,7 @@ export class OnTypeFormattingDispatcher
     position: Position,
     ch: string,
     options: FormattingOptions,
-    cancellationToken: CancellationToken
+    cancellationToken: CancellationToken,
   ): ProviderResult<TextEdit[]> {
     const provider = this.providers[ch];
 
@@ -38,7 +38,7 @@ export class OnTypeFormattingDispatcher
         position,
         ch,
         options,
-        cancellationToken
+        cancellationToken,
       );
     }
 

--- a/src/typeFormatters/ellipsesFormatter.ts
+++ b/src/typeFormatters/ellipsesFormatter.ts
@@ -34,14 +34,14 @@ export class EllipsesFormattingProvider
     position: vscode.Position,
     ch: string,
     options: vscode.FormattingOptions,
-    cancellationToken: vscode.CancellationToken
+    cancellationToken: vscode.CancellationToken,
   ): vscode.TextEdit[] {
     const line: vscode.TextLine = document.lineAt(position.line);
     const range: vscode.Range = new vscode.Range(
       position.line,
       position.character - 3,
       position.line,
-      position.character
+      position.character,
     );
     const prevCh: string =
       position.character > 0 ? line.text.charAt(position.character - 2) : " ";

--- a/src/typeFormatters/quotesFormatter.ts
+++ b/src/typeFormatters/quotesFormatter.ts
@@ -41,14 +41,14 @@ export class QuotesFormattingProvider
     position: vscode.Position,
     ch: string,
     options: vscode.FormattingOptions,
-    cancellationToken: vscode.CancellationToken
+    cancellationToken: vscode.CancellationToken,
   ): vscode.TextEdit[] {
     const line: vscode.TextLine = document.lineAt(position.line);
     const chRange: vscode.Range = new vscode.Range(
       position.line,
       position.character - 1,
       position.line,
-      position.character
+      position.character,
     );
     const prevCh: string =
       position.character > 1 ? line.text.charAt(position.character - 2) : " ";
@@ -70,14 +70,14 @@ export class QuotesFormattingProvider
             return [
               new vscode.TextEdit(
                 chRange,
-                QuotesFormattingProvider.startDoubleQuote
+                QuotesFormattingProvider.startDoubleQuote,
               ),
             ];
           } else {
             return [
               new vscode.TextEdit(
                 chRange,
-                QuotesFormattingProvider.endDoubleQuote
+                QuotesFormattingProvider.endDoubleQuote,
               ),
             ];
           }
@@ -93,14 +93,14 @@ export class QuotesFormattingProvider
             return [
               new vscode.TextEdit(
                 chRange,
-                QuotesFormattingProvider.startSingleQuote
+                QuotesFormattingProvider.startSingleQuote,
               ),
             ];
           } else {
             return [
               new vscode.TextEdit(
                 chRange,
-                QuotesFormattingProvider.endSingleQuote
+                QuotesFormattingProvider.endSingleQuote,
               ),
             ];
           }

--- a/tslint.json
+++ b/tslint.json
@@ -1,31 +1,22 @@
 {
   "defaultSeverity": "warning",
-  "extends": [
-    "tslint:recommended"
-  ],
+  "extends": ["tslint:recommended"],
   "rules": {
+    "trailing-comma": [true, { "multiline": "always", "singleline": "never" }],
     "no-unused-expression": true,
     "no-duplicate-variable": true,
     "curly": true,
     "non-literal-fs-path": false,
     "newline-per-chained-call": false,
     "class-name": true,
-    "semicolon": [
-      true,
-      "always"
-    ],
+    "semicolon": [true, "always"],
     "triple-equals": true,
     "no-relative-imports": false,
     "max-line-length": false,
     "typedef": false,
     "no-string-throw": true,
     "missing-jsdoc": false,
-    "one-line": [
-      true,
-      "check-catch",
-      "check-finally",
-      "check-else"
-    ],
+    "one-line": [true, "check-catch", "check-finally", "check-else"],
     "no-parameter-properties": false,
     "no-parameter-reassignment": false,
     "no-reserved-keywords": false,
@@ -34,11 +25,7 @@
     "align": false,
     "linebreak-style": false,
     "strict-boolean-expressions": false,
-    "await-promise": [
-      true,
-      "Thenable",
-      "PromiseLike"
-    ],
+    "await-promise": [true, "Thenable", "PromiseLike"],
     "completed-docs": false,
     "no-unsafe-any": false,
     "no-backbone-get-set-outside-model": false,
@@ -56,12 +43,7 @@
     "no-bitwise": false,
     "eofline": true,
     "switch-final-break": false,
-    "no-implicit-dependencies": [
-      true,
-      [
-        "vscode"
-      ]
-    ],
+    "no-implicit-dependencies": [true, ["vscode"]],
     "no-unnecessary-type-assertion": false,
     "no-submodule-imports": false,
     "no-redundant-jsdoc": false,


### PR DESCRIPTION
Closes #22 

### Added

- Ability to enable / disable checking of Plain Text documents. Enabled by default.
- Ability to provide a list of   [language ids](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers) that should be considered Plain Text. Defaults to “plaintext”.
- “Force Check as Plain Text Document” command shows on all language ids other   than HTML and Markdown for manual, one-time checking.
- “Clear Document Diagnostics” command to clear LanguageTool diagnostics in support of one-time checking.

### Changed

- Relabeled “Lint Current Document” command to “Check Document”.
- Only HTML and Markdown show the “Check Document” command.