### PR TITLE
Bug - plaintext actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to
 
 Changes not yet released.
 
+### Fixed
+
+- Linter wasn't registered as a Code Actions Provider for the list of plain text
+  IDs in settings, resulting in no suggestions for potential errors
+  ([284](https://github.com/davidlday/vscode-languagetool-linter/issues/284)).
+
 ### Added
 
 - Show warning when spaces exist in either Disabled Rules or Disable Categories

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -25,38 +25,19 @@ export const EXTENSION_DISPLAY_NAME = "languagetool-linter";
 export const EXTENSION_DIAGNOSTIC_SOURCE = "LanguageTool";
 
 // Programming Language IDs
-export const LANGUAGE_ID_MDX = "mdx";
-export const LANGUAGE_ID_MARKDOWN = "markdown";
 export const LANGUAGE_ID_HTML = "html";
+export const LANGUAGE_ID_MARKDOWN = "markdown";
+export const LANGUAGE_ID_MDX = "mdx";
+
+export const SUPPORTED_LANGUAGE_IDS: string[] = [
+  LANGUAGE_ID_HTML,
+  LANGUAGE_ID_MARKDOWN,
+  LANGUAGE_ID_MDX,
+];
 
 // File Scheme
 export const SCHEME_FILE = "file";
 export const SCHEME_UNTITLED = "untitled";
-
-// Document Selectors
-export const SELECTOR_MARKDOWN_FILE: DocumentSelector = {
-  language: LANGUAGE_ID_MARKDOWN,
-  scheme: SCHEME_FILE,
-};
-export const SELECTOR_MARKDOWN_UNTITLED: DocumentSelector = {
-  language: LANGUAGE_ID_MARKDOWN,
-  scheme: SCHEME_UNTITLED,
-};
-export const SELECTOR_HTML_FILE: DocumentSelector = {
-  language: LANGUAGE_ID_HTML,
-  scheme: SCHEME_FILE,
-};
-export const SELECTOR_HTML_UNTITLED: DocumentSelector = {
-  language: LANGUAGE_ID_HTML,
-  scheme: SCHEME_UNTITLED,
-};
-
-export const DOCUMENT_SELECTORS: DocumentSelector[] = [
-  SELECTOR_MARKDOWN_FILE,
-  SELECTOR_MARKDOWN_UNTITLED,
-  SELECTOR_HTML_FILE,
-  SELECTOR_HTML_UNTITLED,
-];
 
 // Configuration Strings
 export const CONFIGURATION_ROOT = "languageToolLinter";
@@ -66,8 +47,9 @@ export const CONFIGURATION_WORKSPACE_IGNORED_WORDS =
   "languageTool.ignoredWordsInWorkspace";
 export const CONFIGURATION_IGNORED_WORD_HINT = "languageTool.ignoredWordHint";
 export const CONFIGURATION_DOCUMENT_LANGUAGE_IDS: string[] = [
-  LANGUAGE_ID_MARKDOWN,
   LANGUAGE_ID_HTML,
+  LANGUAGE_ID_MARKDOWN,
+  LANGUAGE_ID_MDX,
 ];
 export const CONFIGURATION_PLAIN_TEXT_ENABLED = "plainText.enabled";
 export const CONFIGURATION_PLAIN_TEXT_IDS = "plainText.languageIds";

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -14,7 +14,7 @@
  *   limitations under the License.
  */
 
-import { DocumentSelector, OutputChannel, window } from "vscode";
+import { OutputChannel, window } from "vscode";
 
 // General Extension
 export const EXTENSION_TIMEOUT_MS = 500;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,22 +111,25 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   // Register Code Actions Provider for supported languages
-  Constants.DOCUMENT_SELECTORS.forEach((selector: vscode.DocumentSelector) => {
-    context.subscriptions.push(
-      vscode.languages.registerCodeActionsProvider(selector, linter),
-    );
-
-    if (onTypeTriggers) {
+  // Constants.DOCUMENT_SELECTORS.forEach((selector: vscode.DocumentSelector) => {
+  configMan
+    .getDocumentSelectors()
+    .forEach((selector: vscode.DocumentSelector) => {
       context.subscriptions.push(
-        vscode.languages.registerOnTypeFormattingEditProvider(
-          selector,
-          onTypeDispatcher,
-          onTypeTriggers.first,
-          ...onTypeTriggers.more,
-        ),
+        vscode.languages.registerCodeActionsProvider(selector, linter),
       );
-    }
-  });
+
+      if (onTypeTriggers) {
+        context.subscriptions.push(
+          vscode.languages.registerOnTypeFormattingEditProvider(
+            selector,
+            onTypeDispatcher,
+            onTypeTriggers.first,
+            ...onTypeTriggers.more,
+          ),
+        );
+      }
+    });
 
   // Register onDidCloseTextDocument event
   context.subscriptions.push(

--- a/test-fixtures/workspace/.vscode/settings.json
+++ b/test-fixtures/workspace/.vscode/settings.json
@@ -10,5 +10,9 @@
   "languageToolLinter.lintOnOpen": true,
   "languageToolLinter.lintOnChange": true,
   "languageToolLinter.managed.classPath": "/usr/local/opt/languagetool/libexec/languagetool-server.jar",
-  "languageToolLinter.hideRuleIds": false
+  "languageToolLinter.hideRuleIds": false,
+  "languageToolLinter.plainText.languageIds": [
+    "plaintext",
+    "asciidoc"
+  ]
 }

--- a/test-fixtures/workspace/plaintext/basic.asciidoc
+++ b/test-fixtures/workspace/plaintext/basic.asciidoc
@@ -1,0 +1,20 @@
+= AsciiDoc as Plain Text
+D. Day
+
+== Setting It Up
+
+For this to work, add `asciidoc` to the list of plain text IDs in
+the settings. This will prompt for a window reload as well to make
+sure the Linter is registered as a CodeActionsProvider for all the
+IDs.
+
+The Linter will treat AsciiDoc as plain text.
+
+Need to add automated tests.
+
+== Test Text
+
+This is a basic AsciiDoc file. Linter should check spelling. The
+Linter should also not care about word wrapping at 80.
+
+Is speooling enabled?


### PR DESCRIPTION
Closes #284 

Linter now properly registered as a CodeActionsProvider for user-defined plain text IDs.