### PR TITLE
Add languagetool.org premium API support

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,16 @@
           "default": "http://localhost:8081",
           "description": "URL of your LanguageTool server. Defaults to localhost on port 8081."
         },
+        "languageToolLinter.external.username": {
+          "type": "string",
+          "default": "",
+          "description": "Set to get Premium API access if you use the languagetool.org api instance: your username/email as used to log in at languagetool.org."
+        },
+        "languageToolLinter.external.apiKey": {
+          "type": "string",
+          "default": "",
+          "description": "Set to get Premium API access if you use the languagetool.org api instance: your API key."
+        },
         "languageToolLinter.managed.classPath": {
           "type": "string",
           "default": "",

--- a/src/ConfigurationManager.ts
+++ b/src/ConfigurationManager.ts
@@ -18,6 +18,7 @@ import execa from "execa";
 import * as glob from "glob";
 import * as path from "path";
 import * as portfinder from "portfinder";
+import { URL } from "url";
 import {
   commands,
   ConfigurationChangeEvent,
@@ -357,7 +358,16 @@ export class ConfigurationManager implements Disposable {
   private findServiceUrl(serviceType: string): string | undefined {
     switch (serviceType) {
       case Constants.SERVICE_TYPE_EXTERNAL: {
-        return this.getExternalUrl() + Constants.SERVICE_CHECK_PATH;
+        const url = new URL(
+          this.getExternalUrl() + Constants.SERVICE_CHECK_PATH,
+        );
+        const username = this.get("external.username");
+        const apiKey = this.get("external.apiKey");
+        if (username && apiKey) {
+          url.searchParams.set("username", username);
+          url.searchParams.set("apiKey", apiKey);
+        }
+        return url.toString();
       }
       case Constants.SERVICE_TYPE_MANAGED: {
         const port = this.getManagedServicePort();


### PR DESCRIPTION
By adding settings for  `username` and `apiKey`.

fix #438