### PR TITLE
feat: allow in-line ignores for spell errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to
 
 Changes not yet released.
 
+- Allow spell-check rules to be ignored by line. This Works for HTML and
+  markdown, where inline comments are allowed (e.g. pandoc)
+
 ## [0.19.0] - 2021-11-23
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ extension.
   - Make sure 'Editor: Format On Type' is enabled or this feature won't work.
     You can enable it at the document format level as well in your
     `settings.json`.
+- Allow specific rules to be ignored for markdown (pandoc) and HTML
 
 ## Setup
 
@@ -100,6 +101,35 @@ particular attention to:
 3. _LanguageTool: Preferred Variants_: If you set this, then _LanguageTool:
    Language_ must be set to `auto`. If it isn't, the service will throw an
    error.
+
+## Ignore rules inline
+
+You have the chance to ignore specific rules inline to not bloat up your
+ignore list for single words:
+
+    <!-- @IGNORE:UPPERCASE_SENTENCE_START@ -->
+    soll heißen, dass die Nachricht von mir ist, die Koordinaten hat
+    ein kleiner Computer, den Sigrún mir zur Verfügung gestellt hat aus
+    dem irdischen
+    ‚World Geodetic System 1984‘ <!-- @IGNORE:GERMAN_SPELLER_RULE(Geodetic)@ -->
+
+This example will ignore the missing capital letter at the beginning (soll → Soll)
+and an unknown word ('Geodetic')
+
+The optional match word is useful if the same rule is applied to several words
+in the sentence.
+
+The rules can be applied to the current line (e.g. at the end) or at the line
+before.
+
+Syntax:
+
+    @LT-IGNORE:<rulename>(<text-match>)@
+
+The and the `text-match` is optional.
+
+_Note_: Even in pandoc you have to handle the comment in html output. This can
+be done by using a filter.
 
 ## Credits
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "languagetool-linter",
   "displayName": "LanguageTool Linter",
   "description": "LanguageTool integration for VS Code.",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "engines": {
-    "vscode": "^1.43.0"
+    "vscode": "^1.57.0"
   },
   "categories": [
     "Linters"

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -74,3 +74,13 @@ export interface ILanguageToolReplacement {
   value: string;
   shortDescription: string;
 }
+
+// Interface to keep an ignore-statements
+export interface IIgnoreItem {
+  // source line
+  line: number;
+  // matching linter rule
+  ruleId: string;
+  // optional matching text
+  text?: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
+    "target": "ES2020",
     "outDir": "out",
-    "lib": ["es6"],
+    "lib": ["ES2020"] ,
     "moduleResolution": "node",
     "sourceMap": true,
     // "rootDir": "src",


### PR DESCRIPTION
I've created a small addition to your valuable plugin.

I was getting mad of having too much spelling errors for specific words that are used only once in my document. Instead of adding those words to the ignore list, I changed your code to look for a specific token that describes, which rule to be ignored on the current or next line. Optionally you can also add the text match to ignore only specific words:

    <!-- @IGNORE:UPPERCASE_SENTENCE_START@ -->
    soll heißen, dass die Nachricht von mir ist, die Koordinaten hat
    ein kleiner Computer, den Sigrún mir zur Verfügung gestellt hat aus
    dem irdischen
    ‚World Geodetic System 1984‘ <!-- @IGNORE:GERMAN_SPELLER_RULE(Geodetic)@ -->

In this example, 'soll' and 'Geodetic' are not marked as errors (it's a German example, anyhow, the concept should be clear).

To keep the user informed, I still mark them as hints.

**Please Note**

Do to the use of regex-matches I've changed the required js version to ES2020 and the VS-Code min release to 1.57 (where MS introduced ES2020 AFAIR)