### PR TITLE
feat: add languagetool.org premium API support (using form data for the credentials)

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,16 @@
           "default": "http://localhost:8081",
           "description": "URL of your LanguageTool server. Defaults to localhost on port 8081."
         },
+        "languageToolLinter.external.username": {
+          "type": "string",
+          "default": "",
+          "description": "Set to get Premium API access if you use the languagetool.org api instance: your username/email as used to log in at languagetool.org."
+        },
+        "languageToolLinter.external.apiKey": {
+          "type": "string",
+          "default": "",
+          "description": "Set to get Premium API access if you use the languagetool.org api instance: your API key."
+        },
         "languageToolLinter.managed.classPath": {
           "type": "string",
           "default": "",

--- a/src/ConfigurationManager.ts
+++ b/src/ConfigurationManager.ts
@@ -18,6 +18,7 @@ import execa from "execa";
 import * as glob from "glob";
 import * as path from "path";
 import * as portfinder from "portfinder";
+import { URL } from "url";
 import {
   commands,
   ConfigurationChangeEvent,
@@ -357,7 +358,16 @@ export class ConfigurationManager implements Disposable {
   private findServiceUrl(serviceType: string): string | undefined {
     switch (serviceType) {
       case Constants.SERVICE_TYPE_EXTERNAL: {
-        return this.getExternalUrl() + Constants.SERVICE_CHECK_PATH;
+        const url = new URL(
+          this.getExternalUrl() + Constants.SERVICE_CHECK_PATH,
+        );
+        const username = this.get("external.username");
+        const apiKey = this.get("external.apiKey");
+        if (username && apiKey) {
+          url.searchParams.set("username", username);
+          url.searchParams.set("apiKey", apiKey);
+        }
+        return url.toString();
       }
       case Constants.SERVICE_TYPE_MANAGED: {
         const port = this.getManagedServicePort();

--- a/src/ConfigurationManager.ts
+++ b/src/ConfigurationManager.ts
@@ -358,16 +358,7 @@ export class ConfigurationManager implements Disposable {
   private findServiceUrl(serviceType: string): string | undefined {
     switch (serviceType) {
       case Constants.SERVICE_TYPE_EXTERNAL: {
-        const url = new URL(
-          this.getExternalUrl() + Constants.SERVICE_CHECK_PATH,
-        );
-        const username = this.get("external.username");
-        const apiKey = this.get("external.apiKey");
-        if (username && apiKey) {
-          url.searchParams.set("username", username);
-          url.searchParams.set("apiKey", apiKey);
-        }
-        return url.toString();
+        return this.getExternalUrl() + Constants.SERVICE_CHECK_PATH;
       }
       case Constants.SERVICE_TYPE_MANAGED: {
         const port = this.getManagedServicePort();
@@ -401,6 +392,16 @@ export class ConfigurationManager implements Disposable {
         Constants.EXTENSION_OUTPUT_CHANNEL.appendLine(ltKey + ": " + value);
       }
     });
+    // Only add user name and API key to options if set and we are using the
+    // external API
+    if (this.getServiceType() === Constants.SERVICE_TYPE_EXTERNAL) {
+      const username = this.get("external.username");
+      const apiKey = this.get("external.apiKey");
+      if (username && apiKey) {
+        parameters.set("username", username);
+        parameters.set("apiKey", apiKey);
+      }  
+    }
     // Make sure disabled rules and disabled categories do not contain spaces
     const CONFIG_DISABLED_RULES = "languageTool.disabledRules";
     const CONFIG_DISABLED_CATEGORIES = "languageTool.disabledCategories";


### PR DESCRIPTION
This is based on https://github.com/davidlday/vscode-languagetool-linter/pull/480 and fixes https://github.com/davidlday/vscode-languagetool-linter/issues/438.

It implements the changes requested in  https://github.com/davidlday/vscode-languagetool-linter/pull/480#discussion_r976406513

I was able to test this with my own credentials using a text containing a word known to my personal remote dictionary only.