### PR TITLE
feat: add option to set severity levels automatically based on Rule and Categoy

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,11 @@
             "error"
           ]
         },
+        "languageToolLinter.diagnosticSeverityAuto": {
+          "type": "boolean",
+          "default": false,
+          "description": "Spelling mistakes will be set as Error, while punctuation, grammar and typography mistakes as Warning. Anything else as the configured Diagnostic Severity level (recommended to be set as Information when using this option)."
+        },
         "languageToolLinter.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/ConfigurationManager.ts
+++ b/src/ConfigurationManager.ts
@@ -253,6 +253,14 @@ export class ConfigurationManager implements Disposable {
     }
   }
 
+  public getDiagnosticSeverityAuto(): boolean {
+    const severityAuto = this.config.get("diagnosticSeverityAuto");
+    if (severityAuto === true) {
+      return true
+    }
+    return false
+  }
+
   public getClassPath(): string {
     const jarFile: string = this.get("managed.jarFile") as string;
     const classPath: string = this.get("managed.classPath") as string;
@@ -400,7 +408,7 @@ export class ConfigurationManager implements Disposable {
       if (username && apiKey) {
         parameters.set("username", username);
         parameters.set("apiKey", apiKey);
-      }  
+      }
     }
     // Make sure disabled rules and disabled categories do not contain spaces
     const CONFIG_DISABLED_RULES = "languageTool.disabledRules";


### PR DESCRIPTION
This change allows the user to let the severity levels be determined by the Extension as follows:

- All spelling mistakes are underlined in red (Error)
- All punctuation, grammar or typography mistakes in yellow (Warning)
- Any other mistake will be set as the defined Severity Level, which can be set as Information as recommended

The configuration option is a simple boolean that enables this feature. By default, is disabled, so users will notice no change unless explicitly activated.

A potential improvement could be to sophisticate the options, allowing the user to choose which rules or categories are forced to a specific severity level, similar to allowing them to ignore some rules or categories.
