### PR TITLE
fix: bug where language ID ignore list was ignored after saving

### DIFF
--- a/src/ConfigurationManager.ts
+++ b/src/ConfigurationManager.ts
@@ -139,8 +139,8 @@ export class ConfigurationManager implements Disposable {
     return this.config.get("smartFormat.onSave") as boolean;
   }
 
-  // Is Language ID Supported?
-  public isSupportedDocument(document: TextDocument): boolean {
+  // Is language ID supported and enabled?
+  public isLanguageSupportedAndEnabled(document: TextDocument): boolean {
     if (
       document.uri.scheme === Constants.SCHEME_FILE ||
       document.uri.scheme === Constants.SCHEME_UNTITLED
@@ -166,20 +166,7 @@ export class ConfigurationManager implements Disposable {
 
   public getDocumentSelectors(): DocumentSelector[] {
     const selectors: DocumentSelector[] = [];
-    const supportedLanguageIds = Constants.SUPPORTED_LANGUAGE_IDS;
-    const disabledLanguageIds: string[] =
-      this.config.get(Constants.CONFIGURATION_DISABLED_IDS) || [];
-    const languageIds = supportedLanguageIds.filter(
-      (languageId) => !disabledLanguageIds.includes(languageId),
-    );
-
-    if (this.isPlainTextEnabled()) {
-      const plaintextLanguageIds: string[] =
-        this.config.get(Constants.CONFIGURATION_PLAIN_TEXT_IDS) || [];
-      plaintextLanguageIds.forEach((languageId) => {
-        languageIds.push(languageId);
-      });
-    }
+    const languageIds = this.getLanguageIds();
 
     languageIds.forEach((languageId) => {
       const fileSelector: DocumentSelector = {
@@ -223,9 +210,14 @@ export class ConfigurationManager implements Disposable {
     }
   }
 
-  // Get a list of current enabled language Ids
+  // Get a list of language Ids that are supported and enabled
   public getLanguageIds(): string[] {
-    const languageIds: string[] = Constants.SUPPORTED_LANGUAGE_IDS;
+    const supportedLanguageIds = Constants.SUPPORTED_LANGUAGE_IDS;
+    const disabledLanguageIds: string[] =
+      this.config.get(Constants.CONFIGURATION_DISABLED_IDS) || [];
+    const languageIds = supportedLanguageIds.filter(
+      (languageId) => !disabledLanguageIds.includes(languageId),
+    );
     if (this.isPlainTextEnabled()) {
       const plainTextLanguageIds: string[] =
         this.config.get(Constants.CONFIGURATION_PLAIN_TEXT_IDS) || [];

--- a/src/Linter.ts
+++ b/src/Linter.ts
@@ -155,7 +155,7 @@ export class Linter implements CodeActionProvider {
       this.statusBarManager.hide();
       return;
     } else {
-      if (this.configManager.isSupportedDocument(document)) {
+      if (this.configManager.isLanguageSupportedAndEnabled(document)) {
         this.statusBarManager.show();
         if (lint) {
           if (this.configManager.isHideDiagnosticsOnChange()) {
@@ -179,7 +179,7 @@ export class Linter implements CodeActionProvider {
     document: TextDocument,
     timeoutDuration: number = Constants.EXTENSION_TIMEOUT_MS,
   ): void {
-    if (this.configManager.isSupportedDocument(document)) {
+    if (this.configManager.isLanguageSupportedAndEnabled(document)) {
       this.cancelLint(document);
       const uriString = document.uri.toString();
       const timeout = setTimeout(() => {
@@ -260,7 +260,7 @@ export class Linter implements CodeActionProvider {
 
   // Perform Lint on Document
   public lintDocument(document: TextDocument): void {
-    if (this.configManager.isSupportedDocument(document)) {
+    if (this.configManager.isLanguageSupportedAndEnabled(document)) {
       if (document.languageId === Constants.LANGUAGE_ID_MARKDOWN) {
         this.ignoreList = this.buildIgnoreList(document);
         const annotatedMarkdown: string = JSON.stringify(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -230,7 +230,7 @@ export function activate(context: vscode.ExtensionContext): void {
   const smartFormatCommand = vscode.commands.registerTextEditorCommand(
     Constants.COMMAND_SMART_FORMAT,
     (editor: vscode.TextEditor, edit: vscode.TextEditorEdit) => {
-      if (configMan.isSupportedDocument(editor.document)) {
+      if (configMan.isLanguageSupportedAndEnabled(editor.document)) {
         // Revert to regex here for cleaner code.
         const text: string = editor.document.getText();
         const lastOffset: number = text.length;


### PR DESCRIPTION
I implemented a list of disabled language IDs with #806. Unfortunately, I missed that the list was ignored after saving the file. This PR fixes this bug.